### PR TITLE
Allowing SDK to use token vs subscription key

### DIFF
--- a/samples/js/browser/index.html
+++ b/samples/js/browser/index.html
@@ -200,10 +200,7 @@
                 a.send("");
                 a.onload = function() {
                     var token = JSON.parse(atob(this.responseText.split(".")[1]));
-                    regionKey.value = token.region;
                     authorizationToken = this.responseText;
-                    subscriptionKey.disabled = true;
-                    subscriptionKey.value = "using authorization token (hit F5 to refresh)";
                     console.log("Got an authorization token: " + token);
                 }
             }


### PR DESCRIPTION
Currently the page itself doesn't work without entering a subscription key here - even if you have a properly configured token.php file.

I've removed these lines because that restores what I believe is the expected functionality, but I realise this leaves a hanging 'Enter your subscription key here' (which is not needed).

It may be better to reject my PR and add in better handling of 'if you have token.php / auth token then use that, ELSE you can enter a subscription key here'.

## Purpose
Changes from requiring subscription key being entered through the web page to properly using the token.php's provided Authorization Token

## Pull Request Type
Removal of (presumably) unused globally scoped vars

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
