### PR TITLE
fix incorrect event handler registered for Recognizing event in speechtotext-wpf sample.

### DIFF
--- a/samples/csharp/dotnet-windows/speechtotext-wpf/speechtotext-wpf/MainWindow.xaml.cs
+++ b/samples/csharp/dotnet-windows/speechtotext-wpf/speechtotext-wpf/MainWindow.xaml.cs
@@ -321,7 +321,7 @@ namespace MicrosoftSpeechSDKSamples.WpfSpeechRecognitionSample
                 isChecked = this.immediateResultsCheckBox.IsChecked == true;
             });
 
-            EventHandler<SpeechRecognitionEventArgs> recognizingHandler = (sender, e) => RecognizedEventHandler(e, recoType);
+            EventHandler<SpeechRecognitionEventArgs> recognizingHandler = (sender, e) => RecognizingEventHandler(e, recoType);
             if (isChecked)
             {
                 recognizer.Recognizing += recognizingHandler;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* I thought it's mismatch to set  RecognizedEventHandler to recognizingHandler.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
