### PR TITLE
Error handling for the cURL HTTP transfer

### DIFF
--- a/quickstart/js-browser/token.php
+++ b/quickstart/js-browser/token.php
@@ -11,5 +11,11 @@ curl_setopt($ch, CURLOPT_POST, 1);
 curl_setopt($ch, CURLOPT_POSTFIELDS, '{}');
 curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Ocp-Apim-Subscription-Key: ' . $subscriptionKey)); 
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-echo curl_exec($ch);
+
+$res = curl_exec($ch);
+if ($res === FALSE) {
+	trigger_error(curl_error($ch));
+} else {
+	echo $res;
+}
 ?>


### PR DESCRIPTION
Indicating the cURL errors should be better than simply getting a blank output from "token.php".