### PR TITLE
Adding Sample for showing a possible candidate for switching region

### DIFF
--- a/samples/csharp/sharedcontent/console/Program.cs
+++ b/samples/csharp/sharedcontent/console/Program.cs
@@ -143,9 +143,6 @@ namespace MicrosoftSpeechSDKSamples
                     case ConsoleKey.S:
                         SpeechSynthesisServerScenarioSample.SpeechSynthesizeWithPool();
                         break;
-                    case ConsoleKey.X:
-                        SpeechSynthesisSamples.SynthesisWithAutoDetectSourceLanguageAsync().Wait();
-                        break;
                     case ConsoleKey.T:
                         SpeechRecognitionSamples.SpeechRecognitionWithCompressedInputPullStreamAudio().Wait();
                         break;
@@ -155,9 +152,14 @@ namespace MicrosoftSpeechSDKSamples
                     case ConsoleKey.V:
                         TranslationSamples.TranslationWithFileCompressedInputAsync().Wait();
                         break;
-
                     case ConsoleKey.W:
                         SpeechRecognitionSamples.KeywordRecognizer().Wait();
+                        break;
+                    case ConsoleKey.X:
+                        SpeechSynthesisSamples.SynthesisWithAutoDetectSourceLanguageAsync().Wait();
+                        break;
+                    case ConsoleKey.Y:
+                        SpeechRecognitionSamples.RecognitionOnceWithFileAsyncSwitchSecondaryRegion().Wait();
                         break;
 
                     case ConsoleKey.D0:

--- a/samples/csharp/sharedcontent/console/speech_recognition_samples.cs
+++ b/samples/csharp/sharedcontent/console/speech_recognition_samples.cs
@@ -943,5 +943,42 @@ namespace MicrosoftSpeechSDKSamples
                 }
             }
         }
+
+        private static async Task<RecognitionResult> RecognizeOnceAsyncInternal(string key, string region)
+        {
+            RecognitionResult recognitionResult = null;
+            var config = SpeechConfig.FromSubscription(key, region);
+
+            // Creates a speech recognizer using file as audio input.
+            using (var audioInput = AudioConfig.FromWavFileInput(@"whatstheweatherlike.wav"))
+            {
+                using (var recognizer = new SpeechRecognizer(config, audioInput))
+                {
+                    recognitionResult = await recognizer.RecognizeOnceAsync().ConfigureAwait(false);
+                }
+            }
+
+            return recognitionResult;
+        }
+
+        // Speech recognition with backup subscription region.
+        public static async Task RecognitionOnceWithFileAsyncSwitchSecondaryRegion()
+        {
+            // Create a speech resource with primary subscription key and service region.
+            // Also create a speech resource with secondary subscription key and service region 
+            RecognitionResult recognitionResult = await RecognizeOnceAsyncInternal("PrimarySubscriptionKey", "PrimarySubscriptionRegion");
+            if (recognitionResult.Reason == ResultReason.Canceled)
+            {
+                CancellationDetails details = CancellationDetails.FromResult(recognitionResult);
+                if (details.ErrorCode == CancellationErrorCode.ConnectionFailure
+                    || details.ErrorCode == CancellationErrorCode.ServiceUnavailable
+                    || details.ErrorCode == CancellationErrorCode.ServiceTimeout)
+                {
+                    recognitionResult = await RecognizeOnceAsyncInternal("SecondarySubscriptionRegion", "SecondarySubscriptionRegion");
+                }
+            }
+            Console.WriteLine("Recognized {0}", recognitionResult.Text);
+        }
+
     }
 }


### PR DESCRIPTION
Adding Sample for showing a possible candidate for switching region

## Purpose
<!-- Typically, customers use our default endpoints for transcribe audio. However, some customer create assets.  
These assets are backed up regularly and automatically by the repositories themselves so no data loss will occur if a region becomes unavailable.  If a region is non-operational customers must switch to a secondary region to ensure service continuity. The possible scenario when to think towards switching to a secondary region is shown in the sample with this PR -->
* ...

## Pull Request Type
Adding a new sample.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
