### PR TITLE
adding format to integer properties to map to 64 bit integers in targ…

### DIFF
--- a/samples/batch/transcriptionresult_v3.schema.json
+++ b/samples/batch/transcriptionresult_v3.schema.json
@@ -36,6 +36,7 @@
             "$id": "#root/durationInTicks",
             "title": "Duration in ticks",
             "type": "integer",
+            "format": "int64",
             "description": "total audio duration in ticks (1 tick is 100 nanoseconds)",
             "examples": [
                 41200000
@@ -197,6 +198,7 @@
                         "$id": "#root/recognizedPhrases/items/offsetInTicks",
                         "title": "Offset in ticks",
                         "type": "integer",
+                        "format": "int64",
                         "description": "offset in audio of this phrase in ticks (1 tick is 100 nanoseconds)",
                         "examples": [
                             700000
@@ -208,6 +210,7 @@
                         "$id": "#root/recognizedPhrases/items/durationInTicks",
                         "title": "Duration in ticks",
                         "type": "integer",
+                        "format": "int64",
                         "description": "audio duration of this phrase in ticks (1 tick is 100 nanoseconds)",
                         "examples": [
                             15900000
@@ -356,6 +359,7 @@
                                                 "$id": "#root/recognizedPhrases/items/nBest/items/words/items/offsetInTicks",
                                                 "title": "Offset in ticks",
                                                 "type": "integer",
+                                                "format": "int64",
                                                 "description": "offset in audio of this phrase in ticks (1 tick is 100 nanoseconds)",
                                                 "examples": [
                                                     900000
@@ -367,6 +371,7 @@
                                                 "$id": "#root/recognizedPhrases/items/nBest/items/words/items/durationInTicks",
                                                 "title": "Duration in ticks",
                                                 "type": "integer",
+                                                "format": "int64",
                                                 "description": "audio duration of this phrase in ticks (1 tick is 100 nanoseconds)",
                                                 "examples": [
                                                     4800000


### PR DESCRIPTION
Add format to integer properties to map to 64 bit values.

## Purpose
Fixing json schema to allow proper integer handling in java, csharp. The format should avoid mapping properties to 32 bit data types and instead pick 64 integers.

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
