### PR TITLE
Allow 8khz WAV input stream in Java console sample

### DIFF
--- a/samples/csharp/uwp/speechtotext-uwp/README.md
+++ b/samples/csharp/uwp/speechtotext-uwp/README.md
@@ -8,10 +8,10 @@ This sample demonstrates various forms of recognizing speech with C# under the U
 * A Windows PC with Windows 10 Fall Creators Update (10.0; Build 16299) or later.
   Some sample scenarios require a working microphone.
 * [Microsoft Visual Studio 2017](https://www.visualstudio.com/), Community Edition or higher.
-* The **Universal Windows Platform development** workload in Visual Studio.
+* The **Universal Windows Platform development** workload in Visual Studio.  You can enable it in **Tools** \> **Get Tools and Features**.
 * Note: processor target ARM is not yet supported.
 
-  You can enable it in **Tools** \> **Get Tools and Features**.
+ 
 
 ## Build the sample
 
@@ -31,7 +31,7 @@ To debug the app and then run it, press F5 or use **Debug** \> **Start Debugging
 The app displays a graphical user interface (GUI).
 
 * Use the **Subscription Key** text field to enter your subscription key.
-* In the drop down below, choose the region associated with your subscription.
+* In the drop-down below, choose the region associated with your subscription.
 * In the drop-down right below the subscription key, choose the input language.
 * If you'd like to use your microphone, select **Enable Microphone**, which (first time you're clicking it) launches a permission prompt asking for microphone access.
   Approve it.

--- a/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/SpeechRecognitionSamples.java
+++ b/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/SpeechRecognitionSamples.java
@@ -163,11 +163,11 @@ public class SpeechRecognitionSamples {
         // Creates an instance of a speech config with specified
         // subscription key and service region. Replace with your own subscription key
         // and service region (e.g., "westus").
-		SpeechConfig config = SpeechConfig.fromSubscription("YourSubscriptionKey", "YourServiceRegion");
+        SpeechConfig config = SpeechConfig.fromSubscription("YourSubscriptionKey", "YourServiceRegion");
 
         // Creates a speech recognizer using file as audio input.
         // Replace with your own audio file name.
-		AudioConfig audioInput = AudioConfig.fromWavFileInput("YourAudioFile.wav");
+        AudioConfig audioInput = AudioConfig.fromWavFileInput("YourAudioFile.wav");
 
         SpeechRecognizer recognizer = new SpeechRecognizer(config, audioInput);
         {

--- a/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/SpeechRecognitionSamples.java
+++ b/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/SpeechRecognitionSamples.java
@@ -163,11 +163,12 @@ public class SpeechRecognitionSamples {
         // Creates an instance of a speech config with specified
         // subscription key and service region. Replace with your own subscription key
         // and service region (e.g., "westus").
-        SpeechConfig config = SpeechConfig.fromSubscription("YourSubscriptionKey", "YourServiceRegion");
+		SpeechConfig config = SpeechConfig.fromSubscription("YourSubscriptionKey", "YourServiceRegion");
 
         // Creates a speech recognizer using file as audio input.
         // Replace with your own audio file name.
-        AudioConfig audioInput = AudioConfig.fromWavFileInput("YourAudioFile.wav");
+		AudioConfig audioInput = AudioConfig.fromWavFileInput("YourAudioFile.wav");
+
         SpeechRecognizer recognizer = new SpeechRecognizer(config, audioInput);
         {
             // Subscribes to events.
@@ -231,10 +232,15 @@ public class SpeechRecognitionSamples {
         // and service region (e.g., "westus").
         SpeechConfig config = SpeechConfig.fromSubscription("YourSubscriptionKey", "YourServiceRegion");
 
-        // Create an audio stream from a wav file.
-        // Replace with your own audio file name.
-        PullAudioInputStreamCallback callback = new WavStream(new FileInputStream("YourAudioFile.wav"));
-        AudioConfig audioInput = AudioConfig.fromStreamInput(callback);
+        // Create an object that parses the WAV file and implements PullAudioInputStreamCallback to read audio data from the file.
+        // Replace with your own audio file name. 
+        WavStream wavStream = new WavStream(new FileInputStream("YourAudioFile.wav"));
+        
+        // Create a pull audio input stream from the WAV file
+        PullAudioInputStream inputStream = PullAudioInputStream.createPullStream(wavStream, wavStream.getFormat());
+        
+        // Create a configuration object for the recognizer, to read from the pull audio input stream
+        AudioConfig audioInput = AudioConfig.fromStreamInput(inputStream);
 
         // Creates a speech recognizer using audio stream input.
         SpeechRecognizer recognizer = new SpeechRecognizer(config, audioInput);

--- a/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/WavStream.java
+++ b/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/WavStream.java
@@ -1,5 +1,6 @@
 package com.microsoft.cognitiveservices.speech.samples.console;
 
+import com.microsoft.cognitiveservices.speech.audio.AudioStreamFormat;
 import com.microsoft.cognitiveservices.speech.audio.PullAudioInputStreamCallback;
 
 import java.io.IOException;
@@ -7,6 +8,7 @@ import java.io.InputStream;
 
 public class WavStream extends PullAudioInputStreamCallback {
     private final InputStream stream;
+    private AudioStreamFormat format;
 
     public WavStream(InputStream wavStream) {
         try {
@@ -37,6 +39,10 @@ public class WavStream extends PullAudioInputStreamCallback {
             // ignored
         }
     }
+    
+    public AudioStreamFormat getFormat() {
+    	return format;
+    }
     // endregion
 
     // region Wav File helper functions
@@ -64,7 +70,7 @@ public class WavStream extends PullAudioInputStreamCallback {
         return n;
     }
 
-    public InputStream parseWavHeader(InputStream reader) throws IOException {
+    private InputStream parseWavHeader(InputStream reader) throws IOException {
         // Note: assumption about order of chunks
         // Tag "RIFF"
         byte data[] = new byte[4];
@@ -96,9 +102,11 @@ public class WavStream extends PullAudioInputStreamCallback {
         @SuppressWarnings("unused")
         int blockAlign = ReadUInt16(reader);
         int bitsPerSample = ReadUInt16(reader);
+        
+        // Speech SDK supports audio input streams in the following format: 8khz or 16khz sample rate, mono, 16 bit per sample
         ThrowIfFalse(formatTag == 1, "PCM"); // PCM
         ThrowIfFalse(channels == 1, "single channel");
-        ThrowIfFalse(samplesPerSec == 16000, "samples per second");
+        ThrowIfFalse(samplesPerSec == 16000 || samplesPerSec == 8000, "samples per second");
         ThrowIfFalse(bitsPerSample == 16, "bits per sample");
 
         // Until now we have read 16 bytes in format, the rest is cbSize and is ignored
@@ -116,6 +124,10 @@ public class WavStream extends PullAudioInputStreamCallback {
         // data chunk size
         // Note: assumption is that only a single data chunk
         /* int dataLength = */ReadInt32(reader);
+        
+        // Save the stream format, as it may be needed later to configure an input stream to a recognizer
+        this.format = AudioStreamFormat.getWaveFormatPCM(samplesPerSec, (short)bitsPerSample, (short)channels);
+        
         return reader;
     }
 

--- a/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/WavStream.java
+++ b/samples/java/jre/console/src/com/microsoft/cognitiveservices/speech/samples/console/WavStream.java
@@ -41,7 +41,7 @@ public class WavStream extends PullAudioInputStreamCallback {
     }
     
     public AudioStreamFormat getFormat() {
-    	return format;
+        return format;
     }
     // endregion
 


### PR DESCRIPTION
## Purpose
Fix for issue #1231. Speech SDK input stream can support 8khz. However, the WavStream.java WAV parser code does not allow it, and our sample code always creates the input stream using default format (which is 16khz). With this change I allow parsing 8khz WAV files and creating an input stream on the recognizer while explicitly setting its format to allow both 16khz and 8khz streams. Tested with my own WAV files at both sample rates.

Thanks you #carlossapnucivicom for reporting this issue!

Also fix broken sentence in an unrelated document.


<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
