### PR TITLE
Fix security alert in virtual-assistant Java quick-start

### DIFF
--- a/quickstart/java/jre/virtual-assistant/pom.xml
+++ b/quickstart/java/jre/virtual-assistant/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>1.69</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Purpose
Our internal tools alerted us of a security risk that requires an update of the Bouncy Castle Crypto Maven package, in the virtual-assistant quick-start sample.

Tested with our internal "echo-bot" to make sure there is no regression after this change.

Link to the relevant Maven package: https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Update one of the Maven packages to latest version
```
