### PR TITLE
Fix build break in C# sample

### DIFF
--- a/samples/csharp/sharedcontent/console/Program.cs
+++ b/samples/csharp/sharedcontent/console/Program.cs
@@ -17,10 +17,7 @@ namespace MicrosoftSpeechSDKSamples
         private static readonly string invalid = "\n Invalid input, choose again.";
         private static readonly string done = "\n Done!";
 
-        /// <summary>
-        /// Speech recognition with Microsoft Audio Stack enabled.
-        /// </summary>
-        private static void SpeechRecognitionWithMASEnabled()
+        private static void SpeechRecognition()
         {
             ConsoleKeyInfo x;
 


### PR DESCRIPTION
This was a result of bad merge following the update of samples for the 1.20 release. 
