### PR TITLE
Fix YML script such that a build break in VS builds will be logged as task failure and will block check-in

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -90,8 +90,9 @@ jobs:
     inputs:
       maximumCpuCount: true
     displayName: 'Build samples (*.sln)'
-    # Get results from all builds:
-    continueOnError: true
+    # Must set this to false, otherwise a build break will be treated as warning and the task will pass.
+    # This however also means that we will stop building when we hit a build break. We will not continue building other VS projects.
+    continueOnError: false
   # gradle 7.0+ needs Java 11
   - task: JavaToolInstaller@0
     inputs:

--- a/samples/csharp/sharedcontent/console/Program.cs
+++ b/samples/csharp/sharedcontent/console/Program.cs
@@ -17,7 +17,7 @@ namespace MicrosoftSpeechSDKSamples
         private static readonly string invalid = "\n Invalid input, choose again.";
         private static readonly string done = "\n Done!";
 
-        private static void XSpeechRecognition()
+        private static void SpeechRecognition()
         {
             ConsoleKeyInfo x;
 

--- a/samples/csharp/sharedcontent/console/Program.cs
+++ b/samples/csharp/sharedcontent/console/Program.cs
@@ -17,7 +17,7 @@ namespace MicrosoftSpeechSDKSamples
         private static readonly string invalid = "\n Invalid input, choose again.";
         private static readonly string done = "\n Done!";
 
-        private static void SpeechRecognition()
+        private static void XSpeechRecognition()
         {
             ConsoleKeyInfo x;
 


### PR DESCRIPTION
The fix was confirmed in the first commit of this PR, where I intentionally introduced a build break in the C# sample. This is a link to the build, and you see that it is red: https://msasg.visualstudio.com/Skyman/_build/results?buildId=26975675&view=results