### PR TITLE
Fix Task rooting in C# and phrase list setting in all languages

### DIFF
--- a/scenarios/cpp/windows/captioning/captioning/captioning.cpp
+++ b/scenarios/cpp/windows/captioning/captioning/captioning.cpp
@@ -204,7 +204,9 @@ public:
         if (m_userConfig->phraseList.has_value())
         {
             auto grammar = PhraseListGrammar::FromRecognizer(speechRecognizer);
-            grammar->AddPhrase(m_userConfig->phraseList.value());
+            for (auto phrase : Split(m_userConfig->phraseList.value(), ';')) {
+                grammar->AddPhrase(phrase);
+            }
         }
         
         return speechRecognizer;
@@ -296,33 +298,33 @@ int main(int argc, char* argv[])
 {
     const std::string usage = "Usage: captioning.exe [...]\n\n"
 "  HELP\n"
-"    --help                        Show this help and stop.\n\n"
+"    --help                         Show this help and stop.\n\n"
 "  CONNECTION\n"
-"    --key KEY                     Your Azure Speech service subscription key.\n"
-"    --region REGION               Your Azure Speech service region.\n"
-"                                  Examples: westus, eastus\n\n"
+"    --key KEY                      Your Azure Speech service subscription key.\n"
+"    --region REGION                Your Azure Speech service region.\n"
+"                                   Examples: westus, eastus\n\n"
 "  LANGUAGE\n"
-"    --languages LANG1;LANG2       Enable language identification for specified languages.\n"
-"                                  Example: en-US;ja-JP\n\n"
+"    --languages LANG1;LANG2        Enable language identification for specified languages.\n"
+"                                   Example: en-US;ja-JP\n\n"
 "  INPUT\n"
-"    --input FILE                  Input audio from file (default input is the microphone.)\n"
-"    --format FORMAT               Use compressed audio format.\n"
-"                                  If this is not present, uncompressed format (wav) is assumed.\n"
-"                                  Valid only with --file.\n"
-"                                  Valid values: alaw, any, flac, mp3, mulaw, ogg_opus\n\n"
+"    --input FILE                   Input audio from file (default input is the microphone.)\n"
+"    --format FORMAT                Use compressed audio format.\n"
+"                                   If this is not present, uncompressed format (wav) is assumed.\n"
+"                                   Valid only with --file.\n"
+"                                   Valid values: alaw, any, flac, mp3, mulaw, ogg_opus\n\n"
 "  RECOGNITION\n"
-"    --recognizing                 Output Recognizing results (default output is Recognized results only.)\n"
-"                                  These are always written to the console, never to an output file.\n"
-"                                  --quiet overrides this.\n\n"
+"    --recognizing                  Output Recognizing results (default output is Recognized results only.)\n"
+"                                   These are always written to the console, never to an output file.\n"
+"                                   --quiet overrides this.\n\n"
 "  ACCURACY\n"
-"    --phrases PHRASE1;PHRASE2     Example: Constoso;Jessie;Rehaan\n\n"
+"    --phrases ""PHRASE1;PHRASE2""  Example: ""Constoso;Jessie;Rehaan""\n\n"
 "  OUTPUT\n"
-"    --output FILE                 Output captions to text file.\n"
-"    --srt                         Output captions in SubRip Text format (default format is WebVTT.)\n"
-"    --quiet                       Suppress console output, except errors.\n"
-"    --profanity OPTION            Valid values: raw, remove, mask\n"
-"    --threshold NUMBER            Set stable partial result threshold.\n"
-"                                  Default value: 3\n";
+"    --output FILE                  Output captions to text file.\n"
+"    --srt                          Output captions in SubRip Text format (default format is WebVTT.)\n"
+"    --quiet                        Suppress console output, except errors.\n"
+"    --profanity OPTION             Valid values: raw, remove, mask\n"
+"    --threshold NUMBER             Set stable partial result threshold.\n"
+"                                   Default value: 3\n";
 
     try
     {

--- a/scenarios/cpp/windows/captioning/captioning/helper.cpp
+++ b/scenarios/cpp/windows/captioning/captioning/helper.cpp
@@ -12,7 +12,7 @@
 #include <sstream>
 #include "helper.h"
 
-static std::vector<std::string> Split(const std::string& s, char delimiter)
+std::vector<std::string> Split(const std::string& s, char delimiter)
 {
     std::vector<std::string> tokens;
     std::string token;

--- a/scenarios/cpp/windows/captioning/captioning/helper.h
+++ b/scenarios/cpp/windows/captioning/captioning/helper.h
@@ -9,6 +9,8 @@
 using namespace Microsoft::CognitiveServices::Speech;
 using namespace Microsoft::CognitiveServices::Speech::Audio;
 
+std::vector<std::string> Split(const std::string& s, char delimiter);
+
 // Adapted from code in:
 // https://github.com/Azure-Samples/cognitive-services-speech-sdk/blob/master/samples/cpp/windows/console/samples/speech_recognition_samples.cpp
 class BinaryFileReader final : public PullAudioInputStreamCallback

--- a/scenarios/go/captioning/captioning.go
+++ b/scenarios/go/captioning/captioning.go
@@ -290,36 +290,33 @@ func main() {
     var usage string = `Usage: go run captioning.go [...]
 
   HELP
-    --help                        Show this help and stop.
+    --help                          Show this help and stop.
 
   CONNECTION
-    --key KEY                     Your Azure Speech service subscription key.
-    --region REGION               Your Azure Speech service region.
-                                  Examples: westus, eastus
+    --key KEY                       Your Azure Speech service subscription key.
+    --region REGION                 Your Azure Speech service region.
+                                    Examples: westus, eastus
 
   INPUT
-    --input FILE                  Input audio from file (default input is the microphone.)
-    --url URL                     Input audio from URL (default input is the microphone.)
-    --format FORMAT               Use compressed audio format.
-                                  If this is not present, uncompressed format (wav) is assumed.
-                                  Valid only with --file or --url.
-                                  Valid values: alaw, any, flac, mp3, mulaw, ogg_opus
+    --input FILE                    Input audio from file (default input is the microphone.)
+    --url URL                       Input audio from URL (default input is the microphone.)
+    --format FORMAT                 Use compressed audio format.
+                                    If this is not present, uncompressed format (wav) is assumed.
+                                    Valid only with --file or --url.
+                                    Valid values: alaw, any, flac, mp3, mulaw, ogg_opus
 
   RECOGNITION
-    --recognizing                 Output Recognizing results (default output is Recognized results only.)
-                                  These are always written to the console, never to an output file.
-                                  --quiet overrides this.
-
-  ACCURACY
-    --phrases PHRASE1;PHRASE2     Example: Constoso;Jessie;Rehaan
+    --recognizing                   Output Recognizing results (default output is Recognized results only.)
+                                    These are always written to the console, never to an output file.
+                                    --quiet overrides this.
 
   OUTPUT
-    --output FILE                 Output captions to text file.
-    --srt                         Output captions in SubRip Text format (default format is WebVTT.)
-    --quiet                       Suppress console output, except errors.
-    --profanity OPTION            Valid values: raw, remove, mask
-    --threshold NUMBER            Set stable partial result threshold.
-                                  Default value: 3
+    --output FILE                   Output captions to text file.
+    --srt                           Output captions in SubRip Text format (default format is WebVTT.)
+    --quiet                         Suppress console output, except errors.
+    --profanity OPTION              Valid values: raw, remove, mask
+    --threshold NUMBER              Set stable partial result threshold.
+                                    Default value: 3
 `
 
     if CmdOptionExists(os.Args, "--help") {

--- a/scenarios/java/jre/console/captioning/Captioning.java
+++ b/scenarios/java/jre/console/captioning/Captioning.java
@@ -161,7 +161,10 @@ public class Captioning
         if (m_userConfig.getPhraseList().isPresent())
         {
             var grammar = PhraseListGrammar.fromRecognizer(speechRecognizer);
-            grammar.addPhrase(m_userConfig.getPhraseList().get());
+            for (String phrase : m_userConfig.getPhraseList().get().split(";"))
+            {
+                grammar.addPhrase(phrase);
+            }
         }
         
         return speechRecognizer;
@@ -255,35 +258,35 @@ public class Captioning
 .append("Usage: java -cp .;target\\dependency\\* Captioning [...]").append(System.lineSeparator())
 .append(System.lineSeparator())
 .append("  HELP").append(System.lineSeparator())
-.append("    --help                        Show this help and stop.").append(System.lineSeparator())
+.append("    --help                         Show this help and stop.").append(System.lineSeparator())
 .append(System.lineSeparator())
 .append("  CONNECTION").append(System.lineSeparator())
-.append("    --key KEY                     Your Azure Speech service subscription key.").append(System.lineSeparator())
-.append("    --region REGION               Your Azure Speech service region.").append(System.lineSeparator())
-.append("                                  Examples: westus, eastus").append(System.lineSeparator())
+.append("    --key KEY                      Your Azure Speech service subscription key.").append(System.lineSeparator())
+.append("    --region REGION                Your Azure Speech service region.").append(System.lineSeparator())
+.append("                                   Examples: westus, eastus").append(System.lineSeparator())
 .append(System.lineSeparator())
 .append("  INPUT").append(System.lineSeparator())
-.append("    --input FILE                  Input audio from file (default input is the microphone.)").append(System.lineSeparator())
-.append("    --format FORMAT               Use compressed audio format.").append(System.lineSeparator())
-.append("                                  If this is not present, uncompressed format (wav) is assumed.").append(System.lineSeparator())
-.append("                                  Valid only with --file.").append(System.lineSeparator())
-.append("                                  Valid values: alaw, any, flac, mp3, mulaw, ogg_opus").append(System.lineSeparator())
+.append("    --input FILE                   Input audio from file (default input is the microphone.)").append(System.lineSeparator())
+.append("    --format FORMAT                Use compressed audio format.").append(System.lineSeparator())
+.append("                                   If this is not present, uncompressed format (wav) is assumed.").append(System.lineSeparator())
+.append("                                   Valid only with --file.").append(System.lineSeparator())
+.append("                                   Valid values: alaw, any, flac, mp3, mulaw, ogg_opus").append(System.lineSeparator())
 .append(System.lineSeparator())
 .append("  RECOGNITION").append(System.lineSeparator())
-.append("    --recognizing                 Output Recognizing results (default output is Recognized results only.)").append(System.lineSeparator())
-.append("                                  These are always written to the console, never to an output file.").append(System.lineSeparator())
-.append("                                  --quiet overrides this.").append(System.lineSeparator())
+.append("    --recognizing                  Output Recognizing results (default output is Recognized results only.)").append(System.lineSeparator())
+.append("                                   These are always written to the console, never to an output file.").append(System.lineSeparator())
+.append("                                   --quiet overrides this.").append(System.lineSeparator())
 .append(System.lineSeparator())
 .append("  ACCURACY").append(System.lineSeparator())
-.append("    --phrases PHRASE1;PHRASE2     Example: Constoso;Jessie;Rehaan").append(System.lineSeparator())
+.append("    --phrases \"PHRASE1;PHRASE2\"  Example: \"Constoso;Jessie;Rehaan\"").append(System.lineSeparator())
 .append(System.lineSeparator())
 .append("  OUTPUT").append(System.lineSeparator())
-.append("    --output FILE                 Output captions to text file.").append(System.lineSeparator())
-.append("    --srt                         Output captions in SubRip Text format (default format is WebVTT.)").append(System.lineSeparator())
-.append("    --quiet                       Suppress console output, except errors.").append(System.lineSeparator())
-.append("    --profanity OPTION            Valid values: raw, remove, mask").append(System.lineSeparator())
-.append("    --threshold NUMBER            Set stable partial result threshold.").append(System.lineSeparator())
-.append("                                  Default value: 3").append(System.lineSeparator())
+.append("    --output FILE                  Output captions to text file.").append(System.lineSeparator())
+.append("    --srt                          Output captions in SubRip Text format (default format is WebVTT.)").append(System.lineSeparator())
+.append("    --quiet                        Suppress console output, except errors.").append(System.lineSeparator())
+.append("    --profanity OPTION             Valid values: raw, remove, mask").append(System.lineSeparator())
+.append("    --threshold NUMBER             Set stable partial result threshold.").append(System.lineSeparator())
+.append("                                   Default value: 3").append(System.lineSeparator())
 .toString();
 
         try

--- a/scenarios/java/jre/console/captioning/pom.xml
+++ b/scenarios/java/jre/console/captioning/pom.xml
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) Microsoft. All rights reserved.
+Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+Source:
+https://github.com/Azure-Samples/cognitive-services-speech-sdk/blob/master/quickstart/java/jre/speaker-recognition/pom.xml
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.microsoft.cognitiveservices.speech.samples</groupId>
+  <artifactId>quickstart-eclipse</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <repositories>
+    <repository>
+      <id>maven-cognitiveservices-speech</id>
+      <name>Microsoft Cognitive Services Speech Maven Repository</name>
+      <url>https://csspeechstorage.blob.core.windows.net/maven/</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>com.microsoft.cognitiveservices.speech</groupId>
+      <artifactId>client-sdk</artifactId>
+      <version>1.20.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/scenarios/javascript/node/captioning/captioning.js
+++ b/scenarios/javascript/node/captioning/captioning.js
@@ -282,7 +282,7 @@ function SpeechRecognizerFromUserConfig(userConfig)
     if (null !== userConfig.phraseList)
     {
         var grammar = sdk.PhraseListGrammar.fromRecognizer(speechRecognizer);
-        grammar.addPhrase(userConfig.phraseList);
+        userConfig.phraseList.split(";").forEach(phrase => grammar.addPhrase(phrase));
     }
     
     return speechRecognizer;
@@ -352,31 +352,31 @@ function main(args)
     var usage = `Usage: node captioning.js [...]
 
   HELP
-    --help                        Show this help and stop.
+    --help                          Show this help and stop.
 
   CONNECTION
-    --key KEY                     Your Azure Speech service subscription key.
-    --region REGION               Your Azure Speech service region.
-                                  Examples: westus, eastus
+    --key KEY                       Your Azure Speech service subscription key.
+    --region REGION                 Your Azure Speech service region.
+                                    Examples: westus, eastus
 
   INPUT
-    --input FILE                  Input audio from file (default input is the microphone.)
+    --input FILE                    Input audio from file (default input is the microphone.)
 
   RECOGNITION
-    --recognizing                 Output Recognizing results (default output is Recognized results only.)
-                                  These are always written to the console, never to an output file.
-                                  --quiet overrides this.
+    --recognizing                   Output Recognizing results (default output is Recognized results only.)
+                                    These are always written to the console, never to an output file.
+                                    --quiet overrides this.
 
   ACCURACY
-    --phrases PHRASE1;PHRASE2     Example: Constoso;Jessie;Rehaan
+    --phrases "PHRASE1;PHRASE2"     Example: "Constoso;Jessie;Rehaan"
 
   OUTPUT
-    --output FILE                 Output captions to text file.
-    --srt                         Output captions in SubRip Text format (default format is WebVTT.)
-    --quiet                       Suppress console output, except errors.
-    --profanity OPTION            Valid values: raw, remove, mask
-    --threshold NUMBER            Set stable partial result threshold.
-                                  Default value: 3
+    --output FILE                   Output captions to text file.
+    --srt                           Output captions in SubRip Text format (default format is WebVTT.)
+    --quiet                         Suppress console output, except errors.
+    --profanity OPTION              Valid values: raw, remove, mask
+    --threshold NUMBER              Set stable partial result threshold.
+                                    Default value: 3
 `;
 
     if (CmdOptionExists(args, "--help"))

--- a/scenarios/python/console/captioning/captioning.py
+++ b/scenarios/python/console/captioning/captioning.py
@@ -136,7 +136,8 @@ def speech_recognizer_from_user_config(user_config : helper.Read_Only_Dict) -> h
 
     if user_config["phrase_list"] is not None :
         grammar = speechsdk.PhraseListGrammar.from_recognizer(recognizer = speech_recognizer)
-        grammar.addPhrase(user_config["phrase_list"])
+        for phrase in user_config["phrase_list"].split(";") :
+            grammar.addPhrase(phrase)
 
     return helper.Read_Only_Dict({
         "speech_recognizer" : speech_recognizer,
@@ -210,39 +211,39 @@ def recognize_continuous(speech_recognizer : speechsdk.SpeechRecognizer, user_co
 usage = """Usage: python captioning.py [...]
 
   HELP
-    --help                        Show this help and stop.
+    --help                          Show this help and stop.
 
   CONNECTION
-    --key KEY                     Your Azure Speech service subscription key.
-    --region REGION               Your Azure Speech service region.
-                                  Examples: westus, eastus
+    --key KEY                       Your Azure Speech service subscription key.
+    --region REGION                 Your Azure Speech service region.
+                                    Examples: westus, eastus
 
   LANGUAGE
-    --languages LANG1;LANG2       Enable language identification for specified languages.
-                                  Example: en-US;ja-JP
+    --languages LANG1;LANG2         Enable language identification for specified languages.
+                                    Example: en-US;ja-JP
 
   INPUT
-    --input FILE                  Input audio from file (default input is the microphone.)
-    --format FORMAT               Use compressed audio format.
-                                  If this is not present, uncompressed format (wav) is assumed.
-                                  Valid only with --file.
-                                  Valid values: alaw, any, flac, mp3, mulaw, ogg_opus
+    --input FILE                    Input audio from file (default input is the microphone.)
+    --format FORMAT                 Use compressed audio format.
+                                    If this is not present, uncompressed format (wav) is assumed.
+                                    Valid only with --file.
+                                    Valid values: alaw, any, flac, mp3, mulaw, ogg_opus
 
   RECOGNITION
-    --recognizing                 Output Recognizing results (default output is Recognized results only.)
-                                  These are always written to the console, never to an output file.
-                                  --quiet overrides this.
+    --recognizing                   Output Recognizing results (default output is Recognized results only.)
+                                    These are always written to the console, never to an output file.
+                                    --quiet overrides this.
 
   ACCURACY
-    --phrases PHRASE1;PHRASE2     Example: Constoso;Jessie;Rehaan
+    --phrases "PHRASE1;PHRASE2"     Example: "Constoso;Jessie;Rehaan"
 
   OUTPUT
-    --output FILE                 Output captions to text file.
-    --srt                         Output captions in SubRip Text format (default format is WebVTT.)
-    --quiet                       Suppress console output, except errors.
-    --profanity OPTION            Valid values: raw, remove, mask
-    --threshold NUMBER            Set stable partial result threshold.
-                                  Default value: 3
+    --output FILE                   Output captions to text file.
+    --srt                           Output captions in SubRip Text format (default format is WebVTT.)
+    --quiet                         Suppress console output, except errors.
+    --profanity OPTION              Valid values: raw, remove, mask
+    --threshold NUMBER              Set stable partial result threshold.
+                                    Default value: 3
 """
 
 try :


### PR DESCRIPTION
## Purpose
Replace Task.WaitAll with Task.WaitAny in C# to match other samples.
Fix phrase list setting in all languages.
Remove phrase list setting from usage string in Go, as it is not supported there.
Add pom.xml file to Java scenario.

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
