### PR TITLE
[IngestionClient] Fix StartTranscriptionHelper service bus message completion bug

### DIFF
--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -441,7 +441,7 @@
                                 "storageKeyType": "SharedAccessKey",
                                 "administratorLogin": "[parameters('SqlAdministratorLogin')]",
                                 "administratorLoginPassword": "[parameters('SqlAdministratorLoginPassword')]",
-                                "storageUri": "https://ingestionclientstorage.blob.core.windows.net/binaries/14072022.0/IngestionClient.bacpac"
+                                "storageUri": "https://ingestionclientstorage.blob.core.windows.net/binaries/12082022.0/IngestionClient.bacpac"
                             }
                         }
                     ]
@@ -878,7 +878,7 @@
                 "PunctuationMode": "[parameters('PunctuationMode')]",
                 "RetryLimit": "[variables('RetryLimit')]",
                 "StartTranscriptionServiceBusConnectionString": "[listKeys(variables('AuthRuleCT'),'2015-08-01').primaryConnectionString]",
-                "WEBSITE_RUN_FROM_PACKAGE": "[if(variables('timerBasedExecution'),'https://ingestionclientstorage.blob.core.windows.net/binaries/14072022.0/StartTranscriptionByTimer.zip','https://ingestionclientstorage.blob.core.windows.net/binaries/14072022.0/StartTranscriptionByServiceBus.zip')]"
+                "WEBSITE_RUN_FROM_PACKAGE": "[if(variables('timerBasedExecution'),'https://ingestionclientstorage.blob.core.windows.net/binaries/12082022.0/StartTranscriptionByTimer.zip','https://ingestionclientstorage.blob.core.windows.net/binaries/12082022.0/StartTranscriptionByServiceBus.zip')]"
             }
         },
         {
@@ -942,7 +942,7 @@
                 "TextAnalyticsKey": "[concat('@Microsoft.KeyVault(VaultName=', variables('KeyVaultName'), ';SecretName=', variables('TextAnalyticsKeySecretName'), ')')]",
                 "TextAnalyticsRegion": "[parameters('TextAnalyticsRegion')]",
                 "UseSqlDatabase": "[variables('UseSqlDatabase')]",
-                "WEBSITE_RUN_FROM_PACKAGE": "https://ingestionclientstorage.blob.core.windows.net/binaries/14072022.0/FetchTranscription.zip",
+                "WEBSITE_RUN_FROM_PACKAGE": "https://ingestionclientstorage.blob.core.windows.net/binaries/12082022.0/FetchTranscription.zip",
                 "CreateConsolidatedOutputFiles": "[variables('CreateConsolidatedOutputFiles')]",
                 "ConsolidatedFilesOutputContainer": "[variables('ConsolidatedFilesOutputContainer')]",
                 "CreateAudioProcessedContainer": "[variables('CreateAudioProcessedContainer')]",


### PR DESCRIPTION
## Purpose
There's was a bug introduced here
https://github.com/Azure-Samples/cognitive-services-speech-sdk/commit/74c104ab5b102c8d41270f1569fe2ea88b5cbf78
that would result in most service bus messages processed by the StartTranscriptionFunction not being completed (as only the nth message of each chunk would be completed).

This PR fixes it by completing all processed messages.


We didn't notice that bug earlier, since we by default have a maxDeliveryCount of 1 on start transcription service bus messages - so the additional messages would get dead lettered. However, if the maxDeliveryCount is being increased, it would lead to the same service bus message being processed twice.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
