### PR TITLE
[IngestionClient] Fix http request retry, text analytics NRE and prepare for same service bus message on retry

### DIFF
--- a/samples/ingestion/ingestion-client/Connector/BatchClient.cs
+++ b/samples/ingestion/ingestion-client/Connector/BatchClient.cs
@@ -82,41 +82,24 @@ namespace Connector
 
         private static async Task<Uri> PostAsync(string path, string subscriptionKey, string payloadString, TimeSpan timeout)
         {
-            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, path);
-            requestMessage.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-            requestMessage.Content = new StringContent(payloadString, Encoding.UTF8, "application/json");
-
-            var responseMessage = await SendHttpRequestMessage(requestMessage, timeout).ConfigureAwait(false);
-
+            var responseMessage = await SendHttpRequestMessage(HttpMethod.Post, path, subscriptionKey, payloadString, timeout).ConfigureAwait(false);
             return responseMessage.Headers.Location;
         }
 
         private static async Task DeleteAsync(string path, string subscriptionKey, TimeSpan timeout)
         {
-            using var requestMessage = new HttpRequestMessage(HttpMethod.Delete, path);
-            if (!string.IsNullOrEmpty(subscriptionKey))
-            {
-                requestMessage.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-            }
-
-            await SendHttpRequestMessage(requestMessage, timeout).ConfigureAwait(false);
+            await SendHttpRequestMessage(HttpMethod.Delete, path, subscriptionKey, payload: null, timeout: timeout).ConfigureAwait(false);
         }
 
         private static async Task<TResponse> GetAsync<TResponse>(string path, string subscriptionKey, TimeSpan timeout)
         {
-            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, path);
-            if (!string.IsNullOrEmpty(subscriptionKey))
-            {
-                requestMessage.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
-            }
-
-            var responseMessage = await SendHttpRequestMessage(requestMessage, timeout).ConfigureAwait(false);
+            var responseMessage = await SendHttpRequestMessage(HttpMethod.Get, path, subscriptionKey, payload: null, timeout: timeout).ConfigureAwait(false);
 
             var contentString = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
             return JsonConvert.DeserializeObject<TResponse>(contentString);
         }
 
-        private static async Task<HttpResponseMessage> SendHttpRequestMessage(HttpRequestMessage httpRequestMessage, TimeSpan timeout)
+        private static async Task<HttpResponseMessage> SendHttpRequestMessage(HttpMethod httpMethod, string path, string subscriptionKey, string payload, TimeSpan timeout)
         {
             try
             {
@@ -126,6 +109,17 @@ namespace Connector
                 var responseMessage = await RetryPolicy.ExecuteAsync(
                     async (token) =>
                     {
+                        using var httpRequestMessage = new HttpRequestMessage(httpMethod, path);
+                        if (!string.IsNullOrEmpty(subscriptionKey))
+                        {
+                            httpRequestMessage.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+                        }
+
+                        if (!string.IsNullOrEmpty(payload))
+                        {
+                            httpRequestMessage.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+                        }
+
                         var responseMessage = await HttpClient.SendAsync(httpRequestMessage, token).ConfigureAwait(false);
 
                         await responseMessage.EnsureSuccessStatusCodeAsync().ConfigureAwait(false);

--- a/samples/ingestion/ingestion-client/FetchTranscription/TextAnalytics/TextAnalyticsProvider.cs
+++ b/samples/ingestion/ingestion-client/FetchTranscription/TextAnalytics/TextAnalyticsProvider.cs
@@ -71,17 +71,24 @@ namespace TextAnalytics
         /// </summary>
         public async Task<bool> TextAnalyticsRequestsCompleted(IEnumerable<AudioFileInfo> audioFileInfos)
         {
+            if (audioFileInfos == null || !audioFileInfos.Where(audioFileInfo => audioFileInfo.TextAnalyticsRequests != null).Any())
+            {
+                return true;
+            }
+
             var runningTextAnalyticsRequests = new List<TextAnalyticsRequest>();
 
-            if (audioFileInfos.Where(audioFileInfo => audioFileInfo.TextAnalyticsRequests.AudioLevelRequests != null).Any())
-            {
-                runningTextAnalyticsRequests.AddRange(audioFileInfos.SelectMany(audioFileInfo => audioFileInfo.TextAnalyticsRequests.AudioLevelRequests).Where(text => text.Status == TextAnalyticsRequestStatus.Running));
-            }
+            runningTextAnalyticsRequests.AddRange(
+                audioFileInfos
+                    .Where(audioFileInfo => audioFileInfo.TextAnalyticsRequests?.AudioLevelRequests != null)
+                    .SelectMany(audioFileInfo => audioFileInfo.TextAnalyticsRequests.AudioLevelRequests)
+                    .Where(text => text.Status == TextAnalyticsRequestStatus.Running));
 
-            if (audioFileInfos.Where(audioFileInfo => audioFileInfo.TextAnalyticsRequests.UtteranceLevelRequests != null).Any())
-            {
-                runningTextAnalyticsRequests.AddRange(audioFileInfos.SelectMany(audioFileInfo => audioFileInfo.TextAnalyticsRequests.UtteranceLevelRequests).Where(text => text.Status == TextAnalyticsRequestStatus.Running));
-            }
+            runningTextAnalyticsRequests.AddRange(
+                audioFileInfos
+                    .Where(audioFileInfo => audioFileInfo.TextAnalyticsRequests?.UtteranceLevelRequests != null)
+                    .SelectMany(audioFileInfo => audioFileInfo.TextAnalyticsRequests.UtteranceLevelRequests)
+                    .Where(text => text.Status == TextAnalyticsRequestStatus.Running));
 
             var textAnalyticsRequestCompleted = true;
 

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -444,7 +444,7 @@
                                 "storageKeyType": "SharedAccessKey",
                                 "administratorLogin": "[parameters('SqlAdministratorLogin')]",
                                 "administratorLoginPassword": "[parameters('SqlAdministratorLoginPassword')]",
-                                "storageUri": "https://ingestionclientstorage.blob.core.windows.net/binaries/23082022.0/IngestionClient.bacpac"
+                                "storageUri": "https://ingestionclientstorage.blob.core.windows.net/binaries/17102022.0/IngestionClient.bacpac"
                             }
                         }
                     ]
@@ -881,7 +881,7 @@
                 "PunctuationMode": "[parameters('PunctuationMode')]",
                 "RetryLimit": "[variables('RetryLimit')]",
                 "StartTranscriptionServiceBusConnectionString": "[listKeys(variables('AuthRuleCT'),'2015-08-01').primaryConnectionString]",
-                "WEBSITE_RUN_FROM_PACKAGE": "[if(variables('timerBasedExecution'),'https://ingestionclientstorage.blob.core.windows.net/binaries/23082022.0/StartTranscriptionByTimer.zip','https://ingestionclientstorage.blob.core.windows.net/binaries/23082022.0/StartTranscriptionByServiceBus.zip')]"
+                "WEBSITE_RUN_FROM_PACKAGE": "[if(variables('timerBasedExecution'),'https://ingestionclientstorage.blob.core.windows.net/binaries/17102022.0/StartTranscriptionByTimer.zip','https://ingestionclientstorage.blob.core.windows.net/binaries/17102022.0/StartTranscriptionByServiceBus.zip')]"
             }
         },
         {
@@ -945,7 +945,7 @@
                 "TextAnalyticsKey": "[concat('@Microsoft.KeyVault(VaultName=', variables('KeyVaultName'), ';SecretName=', variables('TextAnalyticsKeySecretName'), ')')]",
                 "TextAnalyticsRegion": "[parameters('TextAnalyticsRegion')]",
                 "UseSqlDatabase": "[variables('UseSqlDatabase')]",
-                "WEBSITE_RUN_FROM_PACKAGE": "https://ingestionclientstorage.blob.core.windows.net/binaries/23082022.0/FetchTranscription.zip",
+                "WEBSITE_RUN_FROM_PACKAGE": "https://ingestionclientstorage.blob.core.windows.net/binaries/17102022.0/FetchTranscription.zip",
                 "CreateConsolidatedOutputFiles": "[variables('CreateConsolidatedOutputFiles')]",
                 "ConsolidatedFilesOutputContainer": "[variables('ConsolidatedFilesOutputContainer')]",
                 "CreateAudioProcessedContainer": "[variables('CreateAudioProcessedContainer')]",

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
@@ -574,7 +574,7 @@
                 "ProfanityFilterMode": "[parameters('ProfanityFilterMode')]",
                 "RetryLimit": "[variables('RetryLimit')]",
                 "StartTranscriptionServiceBusConnectionString": "[listKeys(variables('AuthRuleCT'),'2015-08-01').primaryConnectionString]",
-                "WEBSITE_RUN_FROM_PACKAGE": "https://mspublicstorage.blob.core.windows.net/ingestion-client/RealtimeTranscription.zip"
+                "WEBSITE_RUN_FROM_PACKAGE": "https://ingestionclientstorage.blob.core.windows.net/binaries/17102022.0/RealtimeTranscription.zip"
             }
         }
     ],


### PR DESCRIPTION
## Purpose
* Fix bug: Http request retry in Polly was trying to re-use the same HttpRequest - needs to be recreated
* Fix bug: We might run into NRE exceptions if we got only AudioLevelRequests OR UtteranceLevelRequests
* Prepare scenario in which the same audio file is processed twice (which might happen if a message lock is lost, for instance if the function is restarted during processing - or if the audio file is deleted and then re-uploaded).

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
