### PR TITLE
[IngestionClient] Retry HttpStatusCodeException and do not fail whole transcription on transcript download failure

### DIFF
--- a/samples/ingestion/ingestion-client/Connector/BatchClient.cs
+++ b/samples/ingestion/ingestion-client/Connector/BatchClient.cs
@@ -33,7 +33,7 @@ namespace Connector
 
         private static readonly AsyncRetryPolicy RetryPolicy =
             Policy
-                .Handle<HttpRequestException>()
+                .Handle<Exception>(e => e is HttpStatusCodeException || e is HttpRequestException)
                 .WaitAndRetryAsync(MaxNumberOfRetries, retryAttempt => TimeSpan.FromSeconds(2));
 
         public static Task<TranscriptionReportFile> GetTranscriptionReportFileFromSasAsync(string sasUri)

--- a/samples/ingestion/ingestion-client/FetchTranscription/TranscriptionProcessor.cs
+++ b/samples/ingestion/ingestion-client/FetchTranscription/TranscriptionProcessor.cs
@@ -353,45 +353,6 @@ namespace FetchTranscriptionFunction
             var generalErrorsStringBuilder = new StringBuilder();
             var speechTranscriptMappings = new Dictionary<AudioFileInfo, SpeechTranscript>();
 
-            foreach (var resultFile in resultFiles)
-            {
-                log.LogInformation($"Getting result for file {resultFile.Name}");
-
-                try
-                {
-                    var transcriptionResult = await BatchClient.GetSpeechTranscriptFromSasAsync(resultFile.Links.ContentUrl).ConfigureAwait(false);
-
-                    if (string.IsNullOrEmpty(transcriptionResult.Source))
-                    {
-                        var errorMessage = "Transcription source is unknown, skipping evaluation.";
-                        log.LogError(errorMessage);
-
-                        generalErrorsStringBuilder.AppendLine(errorMessage);
-                        continue;
-                    }
-
-                    var audioFileName = StorageConnector.GetFileNameFromUri(new Uri(transcriptionResult.Source));
-                    var audioFileInfo = serviceBusMessage.AudioFileInfos.Where(a => a.FileName == audioFileName).First();
-
-                    if (speechTranscriptMappings.ContainsKey(audioFileInfo))
-                    {
-                        var errorMessage = $"Duplicate audio file in job, skipping: {audioFileInfo.FileName}.";
-                        log.LogError(errorMessage);
-                        generalErrorsStringBuilder.AppendLine(errorMessage);
-                        continue;
-                    }
-
-                    speechTranscriptMappings.Add(audioFileInfo, transcriptionResult);
-                }
-                catch (Exception e) when (e is HttpStatusCodeException || e is HttpRequestException)
-                {
-                    var errorMessage = $"Failed getting speech transcript from content url: {e.Message}";
-                    log.LogError(errorMessage);
-
-                    generalErrorsStringBuilder.AppendLine(errorMessage);
-                }
-            }
-
             if (textAnalyticsProvider != null && (FetchTranscriptionEnvironmentVariables.SentimentAnalysisSetting != SentimentAnalysisSetting.None
                     || FetchTranscriptionEnvironmentVariables.PiiRedactionSetting != PiiRedactionSetting.None || AnalyzeConversationsProvider.IsConversationalPiiEnabled()))
             {
@@ -495,6 +456,45 @@ namespace FetchTranscriptionFunction
                     // Poll for first time with TA request after 1 minute
                     await ServiceBusUtilities.SendServiceBusMessageAsync(FetchServiceBusSender, serviceBusMessage.CreateMessageString(), log, TimeSpan.FromMinutes(1)).ConfigureAwait(false);
                     return;
+                }
+            }
+
+            foreach (var resultFile in resultFiles)
+            {
+                log.LogInformation($"Getting result for file {resultFile.Name}");
+
+                try
+                {
+                    var transcriptionResult = await BatchClient.GetSpeechTranscriptFromSasAsync(resultFile.Links.ContentUrl).ConfigureAwait(false);
+
+                    if (string.IsNullOrEmpty(transcriptionResult.Source))
+                    {
+                        var errorMessage = "Transcription source is unknown, skipping evaluation.";
+                        log.LogError(errorMessage);
+
+                        generalErrorsStringBuilder.AppendLine(errorMessage);
+                        continue;
+                    }
+
+                    var audioFileName = StorageConnector.GetFileNameFromUri(new Uri(transcriptionResult.Source));
+                    var audioFileInfo = serviceBusMessage.AudioFileInfos.Where(a => a.FileName == audioFileName).First();
+
+                    if (speechTranscriptMappings.ContainsKey(audioFileInfo))
+                    {
+                        var errorMessage = $"Duplicate audio file in job, skipping: {audioFileInfo.FileName}.";
+                        log.LogError(errorMessage);
+                        generalErrorsStringBuilder.AppendLine(errorMessage);
+                        continue;
+                    }
+
+                    speechTranscriptMappings.Add(audioFileInfo, transcriptionResult);
+                }
+                catch (Exception e) when (e is HttpStatusCodeException || e is HttpRequestException)
+                {
+                    var errorMessage = $"Failed getting speech transcript from content url: {e.Message}";
+                    log.LogError(errorMessage);
+
+                    generalErrorsStringBuilder.AppendLine(errorMessage);
                 }
             }
 

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -227,7 +227,7 @@
         }
     },
     "variables": {
-        "Version": "v2.0.0",
+        "Version": "v2.0.1",
         "AudioInputContainer": "audio-input",
         "AudioProcessedContainer": "audio-processed",
         "ErrorFilesOutputContainer": "audio-failed",

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
@@ -123,7 +123,7 @@
         }
     },
     "variables": {
-        "Version": "v2.0.0",
+        "Version": "v2.0.1",
         "AudioInputContainer": "audio-input",
         "AudioProcessedContainer": "audio-processed",
         "ErrorFilesOutputContainer": "audio-failed",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Retry on HttpStatusCodeException 
* Catch Http exceptions when downloading files to blob, and write error message instead of failing the complete job

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
