### PR TITLE
Delete .npmrc, add token renewal

### DIFF
--- a/samples/js/browser/.npmrc
+++ b/samples/js/browser/.npmrc
@@ -1,4 +1,0 @@
-# Auto generated file from Gardener Plugin CentralFeedServiceAdoptionPlugin
-registry=https://pkgs.dev.azure.com/msasg/skyman/_packaging/skyman_PublicPackages/npm/registry/
-
-always-auth=true

--- a/samples/js/browser/index.html
+++ b/samples/js/browser/index.html
@@ -520,7 +520,7 @@
                     const renewToken = async () => {
                         await RequestAuthorizationToken();
                         if(!!reco) {
-		                    reco.authorizationToken = authorizationToken;
+                            reco.authorizationToken = authorizationToken;
                         }
                         setTimeout(renewToken, 600000);
                     };

--- a/samples/js/browser/index.html
+++ b/samples/js/browser/index.html
@@ -517,7 +517,14 @@
 
                 // in case we have a function for getting an authorization token, call it.
                 if (typeof RequestAuthorizationToken === "function") {
-                    RequestAuthorizationToken();
+                    const renewToken = async () => {
+                        await RequestAuthorizationToken();
+                        if(!!reco) {
+		                    reco.authorizationToken = authorizationToken;
+                        }
+                        setTimeout(renewToken, 600000);
+                    };
+                    await renewToken();
                 }
             });
         });


### PR DESCRIPTION
Users attempting an npm install (as per readme instructions) will get an auth error, since the skyman npm package registry is specified in the included .npmrc file (which is not needed). Also added token renewal code for long running scenarios.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
