### PR TITLE
fix: update paragraph accuracy score and make it algin with the engine

### DIFF
--- a/samples/python/console/speech_sample.py
+++ b/samples/python/console/speech_sample.py
@@ -864,8 +864,6 @@ def pronunciation_assessment_continuous_from_file():
 
     speech_recognizer.stop_continuous_recognition()
 
-    # We can calculate whole accuracy and fluency scores by duration weighted averaging
-    accuracy_score = sum(i[0] * i[1] for i in zip(accuracy_scores, durations)) / sum(durations)
     # Re-calculate fluency score
     if start_offset is not None:
         fluency_score = sum(valid_durations) / (end_offset - start_offset) * 100
@@ -905,6 +903,15 @@ def pronunciation_assessment_continuous_from_file():
                 final_words += recognized_words[j1:j2]
     else:
         final_words = recognized_words
+
+    # We can calculate whole accuracy by averaging
+    final_accuracy_scores = []
+    for word in final_words:
+        if word.error_type == 'Insertion':
+            continue
+        else:
+            final_accuracy_scores.append(word.accuracy_score)
+    accuracy_score = sum(final_accuracy_scores) / len(final_accuracy_scores)
 
     # Calculate whole completeness score
     completeness_score = len([w for w in final_words if w.error_type == 'None']) / len(reference_words) * 100


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

The previous paragraph-accuracy score with the continuous mode is not aligned with our speech assessment score engine when `miscue` is enabled. So we update it and make it the same with our engine.

## Pull Request Type


<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
