### PR TITLE
Update docs on CustomSpeechTranscriptionsApi

### DIFF
--- a/samples/batch/python/python-client/main.py
+++ b/samples/batch/python/python-client/main.py
@@ -138,7 +138,7 @@ def transcribe():
     client = swagger_client.ApiClient(configuration)
 
     # create an instance of the transcription api class
-    api = swagger_client.CustomSpeechTranscriptionsApi(api_client=client)
+    api = swagger_client.DefaultApi(api_client=self.client)
 
     # Specify transcription properties by passing a dict to the properties parameter. See
     # https://learn.microsoft.com/azure/cognitive-services/speech-service/batch-transcription-create?pivots=rest-api#request-configuration-options
@@ -151,11 +151,13 @@ def transcribe():
     # properties.destination_container_url = "<SAS Uri with at least write (w) permissions for an Azure Storage blob container that results should be written to>"
     # properties.time_to_live = "PT1H"
 
-    # uncomment the following block to enable and configure speaker separation
+    # uncomment the following block to enable and configure speaker separation.
+    # take note that audios only can have 1 channel
     # properties.diarization_enabled = True
     # properties.diarization = swagger_client.DiarizationProperties(
     #     swagger_client.DiarizationSpeakersProperties(min_count=1, max_count=5))
 
+    # take not that you will still need the 'locale' property as passed above
     # properties.language_identification = swagger_client.LanguageIdentificationProperties(["en-US", "ja-JP"])
 
     # Use base models for transcription. Comment this block if you are using a custom model.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
In v3.1, `CustomSpeechTranscriptionsApi` (and a few other APIs, but not used in docs) are being deprecated and replaced with a more generic `DefaultApi`. I realized that sample are not being updated but raised in multiple places:
- https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/1916
- https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/1943
- https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/1743 

This PR hence aims to update docs accordingly and reduce confusion.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
