### PR TITLE
install JDK 17 to fix dotnet build

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -89,6 +89,13 @@ jobs:
       includeNuGetOrg: $(V_INCLUDE_NUGET_ORG)
       restoreSolution: '**\*.sln;!**\embedded-speech\*.sln' # Restoring everything but embedded samples
     displayName: 'Restore NuGet packages'
+  # gradle 7.0+ needs Java 11
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '17'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+    displayName: Use Java 17
   # Note: for now building any platform. In the future, should build all available.
   - task: VSBuild@1
     inputs:
@@ -98,12 +105,5 @@ jobs:
     # Must set this to false, otherwise a build break will be treated as warning and the task will pass.
     # This however also means that we will stop building when we hit a build break. We will not continue building other VS projects.
     continueOnError: false
-  # gradle 7.0+ needs Java 11
-  - task: JavaToolInstaller@0
-    inputs:
-      versionSpec: '17'
-      jdkArchitectureOption: 'x64'
-      jdkSourceOption: 'PreInstalled'
-    displayName: Use Java 17
   - bash: ./ci/run-gradle.sh
     displayName: 'Build samples (gradle)'


### PR DESCRIPTION
## Purpose
 pipeline failed.

 > ##[error]C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.95\targets\Microsoft.Android.Sdk.Tooling.targets(20,5): Error XA0031: Java SDK 11.0 or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk
    

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
