### PR TITLE
Make it easy to run StartTranscription function locally for development.

### DIFF
--- a/samples/ingestion/ingestion-client/.devcontainer/devcontainer.json
+++ b/samples/ingestion/ingestion-client/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "C# (.NET)",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
+	}
+}

--- a/samples/ingestion/ingestion-client/.devcontainer/devcontainer.json
+++ b/samples/ingestion/ingestion-client/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
-	"name": "C# (.NET)",
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
-	"features": {
-		"ghcr.io/devcontainers/features/azure-cli:1": {},
-		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
-	}
+    "name": "C# (.NET)",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/azure-cli:1": {},
+        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
+    }
 }

--- a/samples/ingestion/ingestion-client/.github/dependabot.yml
+++ b/samples/ingestion/ingestion-client/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/samples/ingestion/ingestion-client/.gitignore
+++ b/samples/ingestion/ingestion-client/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+local.settings.json

--- a/samples/ingestion/ingestion-client/StartTranscriptionByTimer/README.md
+++ b/samples/ingestion/ingestion-client/StartTranscriptionByTimer/README.md
@@ -1,0 +1,25 @@
+# Local development instructions
+
+Pre-requisites:
+1. Please follow the instructions on [the main guide](./../Setup/guide.md#ingestion-client-setup-instructions) to deploy the Ingestion Client and associated ecosystem to Azure. 
+2. Reopen the project within a [devcontainer](https://containers.dev/overview). (The devcontainer settings at the root of the project have the tools needed to develop and run this function locally)
+
+To run the StartTranscriptionByTimer function locally, do the following:
+
+1. Run the following command to fetch your Azure Function app settings and save them to local.settings.json:
+
+```
+func azure functionapp fetch-app-settings <function app name>
+```
+
+Note: Replace `<function app name>` with the actual name of your function app that you can get from the Azure Portal. It will look like `StartTranscriptionFunction-20240531T092901Z`.
+
+2. In the local.settings.json file, replace the value of the `AzureSpeechServicesKey` with the actual key for your Azure Speech Service instance. You can get this from the Azure portal.
+
+3. Navigate to the StartTranscription function running on your Azure via the portal, and click on Stop. You need to do this so that you don't have two instances of the StartTranscription function running and listening to the same events when you start the function from your local machine in the next step.
+
+4. Run the following command to start the local function (this will apply your local code changes):
+
+```
+func start
+```

--- a/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionByTimer.csproj
+++ b/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionByTimer.csproj
@@ -15,4 +15,9 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
+    <ItemGroup>
+        <None Update="local.settings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Purpose
This PR adds a devcontainer to the ingestion-client. Additionally, it adds instructions to run the StartTranscriptionByTimer function locally.

If we're happy with this change, I will follow this up with similar changes for the other functions under the ingestion-client in a subsequent PR. 

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Configuration and documentation for developer experience.
```
