### PR TITLE
[IngestionClient] Fix ingestion client build issues introduced in #2428

### DIFF
--- a/samples/ingestion/ingestion-client/Connector/Connector.csproj
+++ b/samples/ingestion/ingestion-client/Connector/Connector.csproj
@@ -6,8 +6,8 @@
         <PackageReference Include="Azure.Storage.Blobs" Version="12.14.0" />
         <PackageReference Include="JsonSubTypes" Version="1.9.0" />
         <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.31" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.31" />
         <PackageReference Include="Polly" Version="7.2.3" />
         <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     </ItemGroup>

--- a/samples/ingestion/ingestion-client/DatabaseMigrator/DatabaseMigrator.csproj
+++ b/samples/ingestion/ingestion-client/DatabaseMigrator/DatabaseMigrator.csproj
@@ -7,9 +7,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.31" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.31" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.31" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Connector\Connector.csproj" />

--- a/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionByTimer.csproj
+++ b/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionByTimer.csproj
@@ -4,7 +4,6 @@
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0"/>
         <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3"/>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Purpose
Commit https://github.com/Azure-Samples/cognitive-services-speech-sdk/commit/aa40573795e9a95862240c732e207666594c9f65 broke the ingestion client build because of package version issues:

See:
https://github.com/Azure-Samples/cognitive-services-speech-sdk/actions/runs/9560869939/job/26353852143

`/home/runner/work/cognitive-services-speech-sdk/cognitive-services-speech-sdk/samples/ingestion/ingestion-client/Connector/Connector.csproj : error NU1202: Package Microsoft.EntityFrameworkCore 8.0.5 is not compatible with net6.0 (.NETCoreApp,Version=v6.0). Package Microsoft.EntityFrameworkCore 8.0.5 supports: net8.0 (.NETCoreApp,Version=v8.0) [/home/runner/work/cognitive-services-speech-sdk/cognitive-services-speech-sdk/samples/ingestion/ingestion-client/BatchIngestionClient.sln]`

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
