### PR TITLE
[IngestionClient] Make the CompletedServiceBusConnectionString an optional deployment parameter

### DIFF
--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -238,6 +238,7 @@
         "CompletedServiceBusConnectionString":
         {
             "type": "SecureString",
+            "defaultValue": "",
             "metadata":
             {
                 "description": "The connection string for the Service Bus Queue where you want to receive the notification of completion of the transcription for each audio file. If left empty, no completion notification will be sent."


### PR DESCRIPTION
## Purpose
This PR adds an empty-string default value to the deployment parameter `CompletedServiceBusConnectionString` to make it an optional parameter during deployment.  

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Deployment config changes
```
![Screenshot 2024-06-24 122847](https://github.com/Azure-Samples/cognitive-services-speech-sdk/assets/1787601/6dec0b57-9a06-48f3-9743-075027a1b413)



