### PR TITLE
[IngestionClient] Fix ARM batch template to use CompletedServiceBusConnectionString as a parameter, not a variable. 

### DIFF
--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -247,7 +247,7 @@
     },
     "variables":
     {
-        "Version": "v2.0.13",
+        "Version": "v2.0.14",
         "AudioInputContainer": "audio-input",
         "AudioProcessedContainer": "audio-processed",
         "ErrorFilesOutputContainer": "audio-failed",

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -238,6 +238,7 @@
         "CompletedServiceBusConnectionString":
         {
             "type": "SecureString",
+            "defaultValue": "",
             "metadata":
             {
                 "description": "The connection string for the Service Bus Queue where you want to receive the notification of completion of the transcription for each audio file. If left empty, no completion notification will be sent."

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -1019,7 +1019,7 @@
                 "ConversationPiiInferenceSource": "[variables('ConversationPiiInferenceSource')]",
                 "ConversationPiiSetting": "[variables('ConversationPiiRedaction')]",
                 "ConversationSummarizationOptions": "[variables('ConversationSummarizationOptions')]",
-                "CompletedServiceBusConnectionString": "[variables('CompletedServiceBusConnectionString')]"
+                "CompletedServiceBusConnectionString": "[parameters('CompletedServiceBusConnectionString')]"
             }
         }
     ],

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
@@ -140,7 +140,7 @@
     },
     "variables":
     {
-        "Version": "v2.0.13",
+        "Version": "v2.0.14",
         "AudioInputContainer": "audio-input",
         "AudioProcessedContainer": "audio-processed",
         "ErrorFilesOutputContainer": "audio-failed",


### PR DESCRIPTION
## Purpose
Fixes an issue with CompletedServiceBusConnectionString being used incorrectly as a variable. It is now being used correctly as a parameter. 

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Deployment config changes.
```
