### PR TITLE
feat: Time interval as a parameter while deploying for StartTranscriptionByTimer function

### DIFF
--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -115,6 +115,15 @@
                 "description": "Enter the address of your private endpoint here (e.g. https://mycustomendpoint.cognitiveservices.azure.com/) if you are connecting with a private endpoint"
             }
         },
+        "StartTranscriptionFunctionTimeInterval":
+        {
+            "defaultValue": "0 */2 * * * *",
+            "type": "String",
+            "metadata":
+            {
+                "description": "The time interval for the timer trigger in the StartTranscription function. The default value is every 2 minutes."
+            }
+        },
         "ProfanityFilterMode":
         {
             "defaultValue": "None",
@@ -937,6 +946,7 @@
                 "MaxPollingDelayInMinutes": "[variables('MaxPollingDelayInMinutes')]",
                 "Locale": "[parameters('Locale')]",
                 "MessagesPerFunctionExecution": "[variables('MessagesPerFunctionExecution')]",
+                "StartTranscriptionFunctionTimeInterval": "[parameters('StartTranscriptionFunctionTimeInterval')]",
                 "ProfanityFilterMode": "[parameters('ProfanityFilterMode')]",
                 "PunctuationMode": "[parameters('PunctuationMode')]",
                 "RetryLimit": "[variables('RetryLimit')]",

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -256,7 +256,7 @@
     },
     "variables":
     {
-        "Version": "v2.0.14",
+        "Version": "v2.0.15",
         "AudioInputContainer": "audio-input",
         "AudioProcessedContainer": "audio-processed",
         "ErrorFilesOutputContainer": "audio-failed",

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateBatch.json
@@ -121,7 +121,7 @@
             "type": "String",
             "metadata":
             {
-                "description": "The time interval for the timer trigger in the StartTranscription function. The default value is every 2 minutes."
+                "description": "The time interval for the timer trigger in the StartTranscription function (https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=python-v2%2Cisolated-process%2Cnodejs-v4&pivots=programming-language-csharp#ncrontab-expressions). The default value is every 2 minutes."
             }
         },
         "ProfanityFilterMode":

--- a/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
+++ b/samples/ingestion/ingestion-client/Setup/ArmTemplateRealtime.json
@@ -140,7 +140,7 @@
     },
     "variables":
     {
-        "Version": "v2.0.14",
+        "Version": "v2.0.15",
         "AudioInputContainer": "audio-input",
         "AudioProcessedContainer": "audio-processed",
         "ErrorFilesOutputContainer": "audio-failed",

--- a/samples/ingestion/ingestion-client/Setup/guide.md
+++ b/samples/ingestion/ingestion-client/Setup/guide.md
@@ -85,7 +85,7 @@ The batch and real time ARM templates are nearly the same. The main differences 
 
 To deploy the required infrastructure, click the button below for Batch mode:
 
-[![Deploy to Azure](ArmTemplateBatch.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Fcognitive-services-speech-sdk%2Fmaster%2Fsamples%2Fingestion%2Fingestion-client%2FSetup%2FArmTemplateBatch.json)
 
 For Real Time mode, use the following button:
 

--- a/samples/ingestion/ingestion-client/Setup/guide.md
+++ b/samples/ingestion/ingestion-client/Setup/guide.md
@@ -85,7 +85,7 @@ The batch and real time ARM templates are nearly the same. The main differences 
 
 To deploy the required infrastructure, click the button below for Batch mode:
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Fcognitive-services-speech-sdk%2Fmaster%2Fsamples%2Fingestion%2Fingestion-client%2FSetup%2FArmTemplateBatch.json)
+[![Deploy to Azure](ArmTemplateBatch.json)
 
 For Real Time mode, use the following button:
 

--- a/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionByTimer.cs
+++ b/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionByTimer.cs
@@ -24,7 +24,7 @@ namespace StartTranscriptionByTimer
         private static readonly ServiceBusReceiver ServiceBusReceiver = ServiceBusClient.CreateReceiver(ServiceBusConnectionStringProperties.Parse(StartTranscriptionEnvironmentVariables.StartTranscriptionServiceBusConnectionString).EntityPath, ServiceBusReceiverOptions);
 
         [FunctionName("StartTranscriptionByTimer")]
-        public static async Task Run([TimerTrigger("0 */2 * * * *")] TimerInfo timerInfo, ILogger log)
+        public static async Task Run([TimerTrigger("%StartTranscriptionFunctionTimeInterval%")] TimerInfo timerInfo, ILogger log)
         {
             if (log == null)
             {

--- a/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionEnvironmentVariables.cs
+++ b/samples/ingestion/ingestion-client/StartTranscriptionByTimer/StartTranscriptionEnvironmentVariables.cs
@@ -55,5 +55,7 @@ namespace StartTranscriptionByTimer
         public static readonly string PunctuationMode = Environment.GetEnvironmentVariable(nameof(PunctuationMode), EnvironmentVariableTarget.Process);
 
         public static readonly string StartTranscriptionServiceBusConnectionString = Environment.GetEnvironmentVariable(nameof(StartTranscriptionServiceBusConnectionString), EnvironmentVariableTarget.Process);
+
+        public static readonly string StartTranscriptionFunctionTimeInterval = Environment.GetEnvironmentVariable(nameof(StartTranscriptionFunctionTimeInterval), EnvironmentVariableTarget.Process);
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Resolves #2448 

## Pull Request Type
What kind of change does this Pull Request introduce?
* This PR adds timer schedule as a configurable parameter for the StartTranscriptionByTimer azure function while deploying Ingestion Client. It sets the default value to `0 */2 * * * *` (2 minutes)

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
