### PR TITLE
Update conversation analysis api version.

### DIFF
--- a/scenarios/csharp/dotnetcore/call-center/call-center/Program.cs
+++ b/scenarios/csharp/dotnetcore/call-center/call-center/Program.cs
@@ -94,7 +94,7 @@ namespace CallCenter
         private const string sentimentAnalysisPath = "language/:analyze-text";
         private const string sentimentAnalysisQuery = "api-version=2022-05-01";
         private const string conversationAnalysisPath = "/language/analyze-conversations/jobs";
-        private const string conversationAnalysisQuery = "api-version=2022-10-01-preview";
+        private const string conversationAnalysisQuery = "api-version=2024-05-15-preview";
         private const string conversationSummaryModelVersion = "latest";
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/364ae17b-2ce9-4b9b-a8d1-bccba71d9e90)

When running the call center sample project, an error 401 is reported when requesting the API. After updating the api-version to 2024-05-15-preview, it becomes normal.