### PR TITLE
Update speech_synthesis_server_scenario_sample.cs

### DIFF
--- a/samples/csharp/sharedcontent/console/speech_synthesis_server_scenario_sample.cs
+++ b/samples/csharp/sharedcontent/console/speech_synthesis_server_scenario_sample.cs
@@ -104,9 +104,9 @@ namespace MicrosoftSpeechSDKSamples
 
         public SynthesisServer(string subscription, string region, string voiceName, SpeechSynthesisOutputFormat outputFormat, int concurrency)
         {
-            // Creates an instance of a speech config with specified endpoint and subscription key.
+            // Creates an instance of a speech config with specified region and subscription key.
             // Replace with your own endpoint and subscription key.
-            var config = SpeechConfig.FromEndpoint(new Uri("https://YourServiceRegion.api.cognitive.microsoft.com"), "YourSubscriptionKey");
+            speechConfig = SpeechConfig.FromSubscription(subscription, region);
 
             // set your voice name
             speechConfig.SpeechSynthesisVoiceName = voiceName;


### PR DESCRIPTION
- Fix null object reference on setting voiceName to speechConfig
- Change from "FromEndpoint" to "FromSubscription"  in order to get rid of cancelation error related to quotas on custom voice endpoint and also to fit more to instruction from documentation
- Get rid of the double need for setting region and subscription key

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
