### PR TITLE
Fix possible vulnerabilities in AJV JSON parser

### DIFF
--- a/samples/cpp/intent-recognition/samples/json_parser/ajv/json_parser.h
+++ b/samples/cpp/intent-recognition/samples/json_parser/ajv/json_parser.h
@@ -128,6 +128,8 @@ namespace ajv {
 
      AJV_FN_NO_INLINE_(JsonParser&) JsonParser::operator=(const JsonParser& other)
      {
+         if (this == &other) return *this;
+
          FreeDups();
 
          m_itemAlloc = 0;
@@ -201,7 +203,7 @@ namespace ajv {
         EndItem(next, nullptr);
         m_items[m_itemAlloc].next = next;
 
-        char *copy = new char[cch + 1];
+        char *copy = new char[cch + 1]();
         m_items[m_itemAlloc].start = copy;
         m_itemAlloc = next;
 

--- a/samples/cpp/intent-recognition/samples/json_parser/ajv/json_reader_view.h
+++ b/samples/cpp/intent-recognition/samples/json_parser/ajv/json_reader_view.h
@@ -19,6 +19,15 @@ namespace ajv {
         JsonReaderView(std::string& json);
         ~JsonReaderView() = default;
 
+        JsonReaderView(const JsonReaderView& other)
+            : JsonView(other), m_readerRoot(InitCopyRoot(other)) {}
+
+        JsonReaderView(JsonReaderView&& other) noexcept
+            : JsonView(std::move(other)), m_readerRoot(InitCopyRoot(other)) {}
+
+        JsonReaderView& operator=(const JsonReaderView&) = delete;
+        JsonReaderView& operator=(JsonReaderView&&) = delete;
+
         const JsonView& View(int* item = nullptr) const { return m_readerRoot.View(item); }
 
         JsonReader Reader() const { return m_readerRoot; }
@@ -88,6 +97,13 @@ namespace ajv {
 
         JsonReader InitRoot(const char* json, size_t jsize);
         JsonReader ParsePtr(const char* json, size_t jsize);
+
+        JsonReader InitCopyRoot(const JsonReaderView& other)
+        {
+            int item = -1;
+            other.m_readerRoot.View(&item);
+            return JsonReader(*this, item);
+        }
 
     };
 

--- a/samples/cpp/intent-recognition/samples/json_parser/ajv/json_string.h
+++ b/samples/cpp/intent-recognition/samples/json_parser/ajv/json_string.h
@@ -132,6 +132,10 @@ namespace ajv {
                                 *dest++ = Escape2Char(src[1]);
                                 src += 2;
                             }
+                            else
+                            {
+                                src++; // skip unrecognized escape backslash to avoid infinite loop
+                            }
                             continue;
                         }
 

--- a/samples/cpp/intent-recognition/samples/json_parser/ajv/json_view.h
+++ b/samples/cpp/intent-recognition/samples/json_parser/ajv/json_view.h
@@ -289,14 +289,14 @@ namespace ajv {
             if (integer != nullptr)
             {
                 char buffer[50];
-                CopyItem(get, buffer, sizeof(buffer));
-                *integer = std::atoi(buffer);
+                if (CopyItem(get, buffer, sizeof(buffer)) != nullptr)
+                    *integer = std::atoi(buffer);
             }
             if (number != nullptr)
             {
                 char buffer[50];
-                CopyItem(get, buffer, sizeof(buffer));
-                *number = std::atof(buffer);
+                if (CopyItem(get, buffer, sizeof(buffer)) != nullptr)
+                    *number = std::atof(buffer);
             }
         }
 
@@ -325,6 +325,7 @@ namespace ajv {
         if (item <= 0 || item >= m_itemCount) return false;
 
         auto& get = m_items[item];
+        if (get.start == nullptr) return false;
 
         auto kind = get.start[0];
         if (IsStartString(kind))
@@ -343,6 +344,7 @@ namespace ajv {
         if (item <= 0 || item >= m_itemCount) return false;
 
         auto& get = m_items[item];
+        if (get.start == nullptr) return false;
         auto kind = get.start[0];
 
         if (IsStartBoolean(kind))
@@ -360,6 +362,7 @@ namespace ajv {
         if (item <= 0 || item >= m_itemCount) return false;
 
         auto& get = m_items[item];
+        if (get.start == nullptr) return false;
         auto kind = get.start[0];
 
         if (IsStartNumber(kind))
@@ -367,7 +370,8 @@ namespace ajv {
             if (value != nullptr)
             {
                 char buffer[50]; 
-                CopyItem(get, buffer, sizeof(buffer));
+                if (CopyItem(get, buffer, sizeof(buffer)) == nullptr)
+                    return true;
 
                 char *bufferEnd;
                 *value = std::strtoll(buffer, &bufferEnd, 10);
@@ -388,6 +392,7 @@ namespace ajv {
         if (item <= 0 || item >= m_itemCount) return false;
 
         auto& get = m_items[item];
+        if (get.start == nullptr) return false;
         auto kind = get.start[0];
 
         if (IsStartNumber(kind))
@@ -395,7 +400,8 @@ namespace ajv {
             if (value != nullptr)
             {
                 char buffer[50];
-                CopyItem(get, buffer, sizeof(buffer));
+                if (CopyItem(get, buffer, sizeof(buffer)) == nullptr)
+                    return true;
 
                 char* bufferEnd;
                 *value = std::strtoull(buffer, &bufferEnd, 10);
@@ -420,6 +426,7 @@ namespace ajv {
         if (item <= 0 || item >= m_itemCount) return false;
 
         auto& get = m_items[item];
+        if (get.start == nullptr) return false;
         auto kind = get.start[0];
 
         if (IsStartNumber(kind))
@@ -427,7 +434,8 @@ namespace ajv {
             if (number != nullptr)
             {
                 char buffer[50];
-                CopyItem(get, buffer, sizeof(buffer));
+                if (CopyItem(get, buffer, sizeof(buffer)) == nullptr)
+                    return true;
                 *number = std::atof(buffer);
             }
             return true;
@@ -692,6 +700,7 @@ namespace ajv {
     AJV_FN_NO_INLINE_(const char*) JsonView::ParseBoolean(const char* psz, const char* zend)
     {
         auto item = InitItem(psz);
+        if (item <= m_itemEnd) return ParseError(psz, zend);
 
         auto isTrue = psz + 3 < zend && psz[0] == 't' && psz[1] == 'r' && psz[2] == 'u' && psz[3] == 'e';
         if (isTrue) return EndItem(item, psz + 3);
@@ -722,6 +731,7 @@ namespace ajv {
         if (psz < zend && (*psz == 'e' || *psz == 'E'))
         {
             psz++;
+            if (psz >= zend) return ParseError(psz, zend);
             if (*psz == '-' || *psz == '+') psz++;
             if (psz >= zend || !IsDigit(*psz)) return ParseError(psz, zend);
             psz = SkipCharsInRange(psz + 1, zend, '0', '9');
@@ -733,6 +743,7 @@ namespace ajv {
     AJV_FN_NO_INLINE_(const char*) JsonView::ParseNull(const char* psz, const char* zend)
     {
         auto item = InitItem(psz);
+        if (item <= m_itemEnd) return ParseError(psz, zend);
 
         auto isNull = psz + 3 < zend && psz[0] == 'n' && psz[1] == 'u' && psz[2] == 'l' && psz[3] == 'l';
         if (isNull) return EndItem(item, psz + 3);


### PR DESCRIPTION
## Purpose
Fix 8 security vulnerabilities (5 critical, 3 moderate) in the AJV header-only C++ JSON parser used by the Intent Recognition module.

VULN-01 (CWE-125): Out-of-bounds heap read in ParseNumber when exponent marker e/E is the last byte in the buffer

VULN-02 (CWE-835): Infinite loop / denial of service in Utf8::Decode when an unrecognized escape sequence (e.g., \x) is encountered

VULN-03 (CWE-416): Use-after-free in JsonParser::operator= on self-assignment — FreeDups() frees strings then AsJson() reads them

VULN-04 (CWE-457): Uninitialized stack buffer passed to atoi/atof/strtoll/strtoull when number token exceeds 49 characters and CopyItem returns nullptr

VULN-05 (CWE-787): Out-of-bounds write via m_items[SIZE_MAX] in ParseBoolean and ParseNull when InitItem returns -1 at max nesting depth

VULN-06 (CWE-476): Null pointer dereference in 5 accessor functions (GetString, GetBool, GetInt64, GetUint64, GetDouble) that skip the null check present in GetKind

VULN-07 (CWE-908): Uninitialized heap memory in DupPtr when the copy loop terminates early on embedded null bytes

VULN-08 (CWE-825): Dangling reference in JsonReaderView after copy/move — compiler-generated constructors leave m_readerRoot.m_view pointing to the source object

All fixes are minimal (4 files, +41/-8 lines), follow existing patterns in the codebase, and were validated with before/after ASAN runs with zero regressions.

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
