### PR TITLE
Fix crash in IntentRecognizer with punctuation-only optional groups (es-MX) and enable CFG

### DIFF
--- a/samples/cpp/intent-recognition/IntentRecognizer/IntentRecognizer.vcxproj
+++ b/samples/cpp/intent-recognition/IntentRecognizer/IntentRecognizer.vcxproj
@@ -63,6 +63,9 @@
       <PreprocessorDefinitions>_DEBUG;INTENTRECOGNIZER_EXPORTS;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\samples\intent_api;..\samples\intent_recognizer\include;..\samples\json_parser;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 /Gw %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -80,6 +83,8 @@
       <PreprocessorDefinitions>NDEBUG;INTENTRECOGNIZER_EXPORTS;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\samples\intent_api;..\samples\intent_recognizer\include;..\samples\json_parser;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 /Gw %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>

--- a/samples/cpp/intent-recognition/samples/intent_recognizer/pattern_matching_model.cpp
+++ b/samples/cpp/intent-recognition/samples/intent_recognizer/pattern_matching_model.cpp
@@ -466,6 +466,10 @@ Maybe<std::shared_ptr<CSpxIntentMatchResult>> CSpxPatternMatchingModel::CheckPat
 
             for (auto& possiblePhrase : possiblePhrases)
             {
+                if (possiblePhrase.empty())
+                {
+                    continue;
+                }
                 // Let's treat each possiblePhrase as a separate possible pattern.
                 std::string newPattern;
                 if (*possiblePhrase.begin() != '{' &&


### PR DESCRIPTION
## Summary

Fixes a crash in `IntentRecognizer.dll` when processing Spanish (es-MX) locale patterns containing optional groups with only punctuation characters (e.g. `[¿]`, `[¡]`).

Also enables Control Flow Guard (CFG) and explicit PDB debug info for the IntentRecognizer project.

## Problem

Patterns like `[¿]qué puedo decir[?]` crash during `CheckPattern` because:

1. `ParseGroupedPhrases` parses inside `[¿]`
2. `SkipPatternPunctuationAndWhitespace` strips `¿` (it's in es locale `PatternPunctuation`)
3. An empty string is pushed to `possiblePhrases`
4. `*possiblePhrase.begin()` dereferences `begin()` on an empty string — **undefined behavior**

In **Debug builds**, MSVC iterator validation catches this as `FAST_FAIL_INVALID_ARG` (0xc0000409). In **Release builds**, SSO causes it to silently read `'\0'`, which happens to produce correct behavior.

## Fix

- **`pattern_matching_model.cpp`**: Add `empty()` guard to skip empty phrases before dereferencing `begin()`
- **`IntentRecognizer.vcxproj`**: Enable `/guard:cf` (CFG) for Debug+Release; add `ProgramDatabase` debug info for Debug

**`IntentRecognizer.vcxproj`**
- Enable Control Flow Guard (`/guard:cf`) for Debug and Release
- Set `ProgramDatabase` debug info format for Debug builds
- Use static CRT linking (`/MTd` for Debug, `/MT` for Release)


<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
