### PR TITLE
Upgrade Netty dependencies in Java/Android public samples

### DIFF
--- a/quickstart/java/android/from-microphone/app/build.gradle
+++ b/quickstart/java/android/from-microphone/app/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'

--- a/quickstart/java/android/keyword-recognizer-stream/app/build.gradle
+++ b/quickstart/java/android/keyword-recognizer-stream/app/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'

--- a/quickstart/java/android/keyword-recognizer/app/build.gradle
+++ b/quickstart/java/android/keyword-recognizer/app/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'

--- a/quickstart/java/android/text-to-speech/app/build.gradle
+++ b/quickstart/java/android/text-to-speech/app/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'

--- a/samples/java/android/SpeechSynthesis/app/build.gradle
+++ b/samples/java/android/SpeechSynthesis/app/build.gradle
@@ -37,7 +37,8 @@ android {
 
 dependencies {
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'

--- a/samples/java/android/avatar/app/build.gradle
+++ b/samples/java/android/avatar/app/build.gradle
@@ -36,7 +36,8 @@ android {
 
 dependencies {
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.google.android.material:material:1.12.0'

--- a/samples/java/android/compressed-input/app/build.gradle
+++ b/samples/java/android/compressed-input/app/build.gradle
@@ -35,7 +35,8 @@ android {
 
 dependencies {
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'

--- a/samples/java/android/embedded-speech/app/build.gradle
+++ b/samples/java/android/embedded-speech/app/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk-embedded:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk-embedded:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'

--- a/samples/java/android/sdkdemo/app/build.gradle
+++ b/samples/java/android/sdkdemo/app/build.gradle
@@ -35,7 +35,8 @@ android {
 
 dependencies {
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
     // Diff lib for pronunciation assessment
     implementation "io.github.java-diff-utils:java-diff-utils:4.11"
 

--- a/samples/kotlin/android/continuous-reco/app/build.gradle
+++ b/samples/kotlin/android/continuous-reco/app/build.gradle
@@ -40,5 +40,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation "com.microsoft.cognitiveservices.speech:client-sdk:1.49.1"
+    implementation "com.microsoft.cognitiveservices.speech:client-sdk:1.48.1"
+    implementation platform("io.netty:netty-bom:4.2.13.Final")
 }

--- a/samples/kotlin/android/tts-pause-example/app/build.gradle
+++ b/samples/kotlin/android/tts-pause-example/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    implementation "com.microsoft.cognitiveservices.speech:client-sdk:1.49.1"
+    implementation "com.microsoft.cognitiveservices.speech:client-sdk:1.48.1"
+    implementation platform("io.netty:netty-bom:4.2.13.Final")
 
 }

--- a/scenarios/java/android/language-learning/app/build.gradle
+++ b/scenarios/java/android/language-learning/app/build.gradle
@@ -35,7 +35,8 @@ android {
 
 dependencies {
     // Speech SDK
-    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.49.1'
+    implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.48.1'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
     // Diff lib for pronunciation assessment
     implementation "io.github.java-diff-utils:java-diff-utils:4.11"
 

--- a/scenarios/java/jre/console/captioning/pom.xml
+++ b/scenarios/java/jre/console/captioning/pom.xml
@@ -46,16 +46,33 @@ mvn clean dependency:copy-dependencies
     <dependency>
       <groupId>com.microsoft.cognitiveservices.speech</groupId>
       <artifactId>client-sdk</artifactId>
-      <version>1.49.1</version>
+      <version>1.48.1</version>
     </dependency>
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>4.2.13.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.2.13.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>4.2.13.Final</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.18.6</version>
+        <version>2.21.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR syncs the public sample dependency updates from internal Carbon PR #33889.

## What changed
- Added `implementation platform('io.netty:netty-bom:4.2.13.Final')` to affected Android public samples.
- Updated Java JRE captioning sample POM to use Netty dependency management aligned with the security upgrade.

## Why
These updates align public samples with the Netty security remediation already applied in the internal Carbon repo.

## Source
- Internal branch: `user/v-mohazaki/upgrade-nutty-packages`
- Internal PR: `!33889` (Azure DevOps)
