### PR TITLE
Add Python and C# samples for personal voice design

### DIFF
--- a/samples/custom-voice/csharp/CustomVoiceSample/Program.cs
+++ b/samples/custom-voice/csharp/CustomVoiceSample/Program.cs
@@ -11,8 +11,8 @@ public class Program
         // ProfessionalVoiceSample.ProfessionalVoiceTestAsync().Wait();
 
         // Uncomment to run Voice Design Sample (creates a personal voice from a text prompt)
-        VoiceDesignSample.VoiceDesignTestAsync().Wait();
+        // VoiceDesignSample.VoiceDesignTestAsync().Wait();
 
-        // PersonalVoiceSample.PersonalVoiceTestAsync().Wait();
+        PersonalVoiceSample.PersonalVoiceTestAsync().Wait();
     }
 }

--- a/samples/custom-voice/csharp/CustomVoiceSample/Program.cs
+++ b/samples/custom-voice/csharp/CustomVoiceSample/Program.cs
@@ -10,6 +10,9 @@ public class Program
         // Uncomment to run Professional Voice Sample
         // ProfessionalVoiceSample.ProfessionalVoiceTestAsync().Wait();
 
-        PersonalVoiceSample.PersonalVoiceTestAsync().Wait();
+        // Uncomment to run Voice Design Sample (creates a personal voice from a text prompt)
+        VoiceDesignSample.VoiceDesignTestAsync().Wait();
+
+        // PersonalVoiceSample.PersonalVoiceTestAsync().Wait();
     }
 }

--- a/samples/custom-voice/csharp/CustomVoiceSample/VoiceDesignSample.cs
+++ b/samples/custom-voice/csharp/CustomVoiceSample/VoiceDesignSample.cs
@@ -1,0 +1,173 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+//
+
+// Provide credentials via SPEECH_KEY / SPEECH_REGION environment variables, or by editing the
+// constants below.
+
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+
+public class VoiceDesignSample
+{
+    private static readonly string SpeechKey = Environment.GetEnvironmentVariable("SPEECH_KEY") ?? "<paste-your-speech-resource-key-here>";
+    private static readonly string SpeechRegion = Environment.GetEnvironmentVariable("SPEECH_REGION") ?? "eastus";
+
+    private const string VoicePrompt = "An elderly man in his seventies with a low, bold, strong voice. He speaks slowly and deliberately.";
+    private const string SampleText = "Hello, I am an AI generated voice. Nice to meet you.";
+    private const string Locale = "en-US";
+    private const int CandidateCount = 3;
+    private const int CandidateIndex = 0; // Which candidate to turn into a personal voice (audition the preview WAVs first).
+
+    private const string ProjectId = "voice-design-sample-project";
+    private static readonly string PersonalVoiceId = $"voice-design-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+
+    private const string SynthesisText = "This voice was created from a text prompt -- no recording, no consent file, just words.";
+    private static readonly string OutputDir = Path.Combine(AppContext.BaseDirectory, "voice_design_output");
+
+    private const string ApiVersion = "2024-02-01-preview";
+
+    public static async Task VoiceDesignTestAsync()
+    {
+        if (SpeechKey.StartsWith("<"))
+        {
+            Console.WriteLine("ERROR: SPEECH_KEY is not set. Set the SPEECH_KEY env var or edit the constant in VoiceDesignSample.cs.");
+            return;
+        }
+
+        Directory.CreateDirectory(OutputDir);
+
+        using var http = new HttpClient { BaseAddress = new Uri($"https://{SpeechRegion}.api.cognitive.microsoft.com") };
+        http.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", SpeechKey);
+
+        await EnsureProjectAsync(http, ProjectId);
+
+        var candidates = await DesignVoiceCandidatesAsync(http, VoicePrompt, SampleText, Locale, CandidateCount);
+        await DownloadPreviewsAsync(candidates, OutputDir);
+
+        if (CandidateIndex < 0 || CandidateIndex >= candidates.Count)
+        {
+            Console.WriteLine($"ERROR: CandidateIndex={CandidateIndex} is out of range (got {candidates.Count} candidates).");
+            return;
+        }
+        var chosen = candidates[CandidateIndex];
+
+        var speakerProfileId = await CreatePersonalVoiceAsync(http, ProjectId, PersonalVoiceId, chosen.GetProperty("id").GetString()!);
+
+        var outputPath = Path.Combine(OutputDir, "voice_design_output.wav");
+        await SynthesizeAsync(speakerProfileId, SynthesisText, outputPath);
+    }
+
+    // Step 1: create the personal-voice project if it doesn't already exist.
+    private static async Task EnsureProjectAsync(HttpClient http, string projectId)
+    {
+        var response = await http.PutAsJsonAsync(
+            $"/customvoice/projects/{projectId}?api-version={ApiVersion}",
+            new { kind = "PersonalVoice", description = "voice design sample" });
+        response.EnsureSuccessStatusCode();
+        await PrintResponseAsync($"PUT project {projectId}", response);
+    }
+
+    // Step 2: design voice candidates from the prompt.
+    private static async Task<List<JsonElement>> DesignVoiceCandidatesAsync(HttpClient http, string voicePrompt, string sampleText, string locale, int candidateCount)
+    {
+        var response = await http.PostAsJsonAsync(
+            $"/customvoice/personalvoices:design?api-version={ApiVersion}",
+            new
+            {
+                VoicePrompt = voicePrompt,
+                SampleText = sampleText,
+                candidateCount,
+                locale,
+            });
+        response.EnsureSuccessStatusCode();
+        var body = await PrintResponseAsync("POST personalvoices:design", response);
+
+        var candidates = body.GetProperty("candidates").EnumerateArray().ToList();
+        if (candidates.Count == 0)
+        {
+            throw new InvalidOperationException("Service returned no candidates. Try a more descriptive VoicePrompt.");
+        }
+        return candidates;
+    }
+
+    // Step 3: download each candidate's preview WAV. The uri is a short-lived SAS URL.
+    private static async Task DownloadPreviewsAsync(List<JsonElement> candidates, string outputDir)
+    {
+        using var downloader = new HttpClient();
+        for (int i = 0; i < candidates.Count; i++)
+        {
+            var id = candidates[i].GetProperty("id").GetString();
+            var uri = candidates[i].GetProperty("uri").GetString()!;
+            var path = Path.Combine(outputDir, $"candidate_{i}.wav");
+            await using (var fs = File.Create(path))
+            await using (var stream = await downloader.GetStreamAsync(uri))
+            {
+                await stream.CopyToAsync(fs);
+            }
+            Console.WriteLine($"  candidate {i}: id={id}  preview -> {path}");
+        }
+        Console.WriteLine();
+    }
+
+    // Step 4: turn the chosen candidate into a personal voice and return its speakerProfileId.
+    private static async Task<string> CreatePersonalVoiceAsync(HttpClient http, string projectId, string personalVoiceId, string candidateId)
+    {
+        var response = await http.PutAsJsonAsync(
+            $"/customvoice/personalvoices/{personalVoiceId}?api-version={ApiVersion}",
+            new { projectId, candidateId });
+        response.EnsureSuccessStatusCode();
+        var body = await PrintResponseAsync($"PUT personalvoices/{personalVoiceId}", response);
+        return body.GetProperty("speakerProfileId").GetString()!;
+    }
+
+    // Step 5: synthesize speech using the new personal voice. Identical to any other personal voice.
+    private static async Task SynthesizeAsync(string speakerProfileId, string text, string outputPath)
+    {
+        var ssml = "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' " +
+                   "xmlns:mstts='http://www.w3.org/2001/mstts' xml:lang='en-US'>" +
+                   "<voice name='DragonLatestNeural'>" +
+                   $"<mstts:ttsembedding speakerProfileId='{speakerProfileId}'>" +
+                   $"<lang xml:lang='{Locale}'>{text}</lang>" +
+                   "</mstts:ttsembedding></voice></speak>";
+
+        var speechConfig = SpeechConfig.FromSubscription(SpeechKey, SpeechRegion);
+        speechConfig.SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.Riff24Khz16BitMonoPcm);
+        using var audioConfig = AudioConfig.FromWavFileOutput(outputPath);
+        using var synthesizer = new SpeechSynthesizer(speechConfig, audioConfig);
+
+        using var result = await synthesizer.SpeakSsmlAsync(ssml).ConfigureAwait(false);
+        if (result.Reason == ResultReason.SynthesizingAudioCompleted)
+        {
+            Console.WriteLine($"Synthesized audio -> {outputPath}");
+        }
+        else if (result.Reason == ResultReason.Canceled)
+        {
+            var details = SpeechSynthesisCancellationDetails.FromResult(result);
+            throw new InvalidOperationException($"Synthesis canceled: {details.Reason}. {details.ErrorDetails}");
+        }
+    }
+
+    private static async Task<JsonElement> PrintResponseAsync(string label, HttpResponseMessage response)
+    {
+        var text = await response.Content.ReadAsStringAsync();
+        Console.WriteLine($"--- {label} [{(int)response.StatusCode}] ---");
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            Console.WriteLine(JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true }));
+            Console.WriteLine();
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            Console.WriteLine(text);
+            Console.WriteLine();
+            return default;
+        }
+    }
+}

--- a/samples/custom-voice/python/README.md
+++ b/samples/custom-voice/python/README.md
@@ -10,5 +10,9 @@ pip install -r requirements.txt
 
 ## Run the sample code
 
-The professional voice sample code is [professional_voice_sample.py](professional_voice_sample.py). The personal voice sample code is [personal_voice_sample.py](personal_voice_sample.py). They can be run using Python 3.7 or higher.
+Samples (Python 3.7+):
+
+- [professional_voice_sample.py](professional_voice_sample.py)
+- [personal_voice_sample.py](personal_voice_sample.py)
+- [voice_design_sample.py](voice_design_sample.py)
 

--- a/samples/custom-voice/python/voice_design_sample.py
+++ b/samples/custom-voice/python/voice_design_sample.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+"""
+Voice design sample.
+
+Provide credentials by editing the constants below, exporting SPEECH_KEY / SPEECH_REGION as
+environment variables, or setting them in a VS Code launch.json "env" block.
+"""
+
+import json
+import os
+import sys
+import uuid
+
+import azure.cognitiveservices.speech as speechsdk
+import requests
+
+# ==================================================================================
+# Configuration -- edit these or set the matching environment variables.
+# ==================================================================================
+
+SPEECH_KEY = os.environ.get("SPEECH_KEY", "<paste-your-speech-resource-key-here>")
+SPEECH_REGION = os.environ.get("SPEECH_REGION", "eastus")
+
+VOICE_PROMPT = "An elderly man in his seventies with a low, bold, strong voice. He speaks slowly and deliberately."
+SAMPLE_TEXT = "Hello, I am an AI generated voice. Nice to meet you."
+LOCALE = "en-US"
+CANDIDATE_COUNT = 3
+CANDIDATE_INDEX = 0  # Which candidate to turn into a personal voice (audition the preview WAVs first).
+
+PROJECT_ID = "voice-design-sample-project"
+PERSONAL_VOICE_ID = f"voice-design-{uuid.uuid4().hex[:8]}"
+
+SYNTHESIS_TEXT = "This voice was created from a text prompt -- no recording, no consent file, just words."
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "voice_design_output")
+
+CUSTOM_VOICE_HOST = f"https://{SPEECH_REGION}.api.cognitive.microsoft.com"
+API_VERSION = "2024-02-01-preview"
+
+
+def _print_response(label: str, response: requests.Response) -> None:
+    print(f"--- {label} [{response.status_code}] ---")
+    try:
+        print(json.dumps(response.json(), indent=2))
+    except ValueError:
+        print(response.text)
+    print()
+
+
+# Step 1: create the personal-voice project if it doesn't already exist.
+def ensure_project(project_id: str) -> None:
+    url = f"{CUSTOM_VOICE_HOST}/customvoice/projects/{project_id}?api-version={API_VERSION}"
+    response = requests.put(
+        url,
+        headers={"Ocp-Apim-Subscription-Key": SPEECH_KEY, "Content-Type": "application/json"},
+        json={"kind": "PersonalVoice", "description": "voice design sample"},
+    )
+    response.raise_for_status()
+    _print_response(f"PUT project {project_id}", response)
+
+
+# Step 2: design voice candidates from the prompt.
+def design_voice_candidates(voice_prompt: str, sample_text: str, locale: str, candidate_count: int) -> list:
+    url = f"{CUSTOM_VOICE_HOST}/customvoice/personalvoices:design?api-version={API_VERSION}"
+    body = {
+        "VoicePrompt": voice_prompt,
+        "SampleText": sample_text,
+        "candidateCount": candidate_count,
+        "locale": locale,
+    }
+    response = requests.post(
+        url,
+        headers={"Ocp-Apim-Subscription-Key": SPEECH_KEY, "Content-Type": "application/json"},
+        json=body,
+    )
+    response.raise_for_status()
+    _print_response("POST personalvoices:design", response)
+    candidates = response.json().get("candidates", [])
+    if not candidates:
+        raise RuntimeError("Service returned no candidates. Try a more descriptive VOICE_PROMPT.")
+    return candidates
+
+
+# Step 3: download each candidate's preview WAV. The uri is a short-lived SAS URL.
+def download_previews(candidates: list, output_dir: str) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    for i, candidate in enumerate(candidates):
+        path = os.path.join(output_dir, f"candidate_{i}.wav")
+        with requests.get(candidate["uri"], stream=True) as r:
+            r.raise_for_status()
+            with open(path, "wb") as f:
+                for chunk in r.iter_content(chunk_size=64 * 1024):
+                    f.write(chunk)
+        print(f"  candidate {i}: id={candidate['id']}  preview -> {path}")
+    print()
+
+
+# Step 4: turn the chosen candidate into a personal voice and return its speakerProfileId.
+def create_personal_voice(project_id: str, personal_voice_id: str, candidate_id: str) -> str:
+    url = f"{CUSTOM_VOICE_HOST}/customvoice/personalvoices/{personal_voice_id}?api-version={API_VERSION}"
+    response = requests.put(
+        url,
+        headers={"Ocp-Apim-Subscription-Key": SPEECH_KEY, "Content-Type": "application/json"},
+        json={"projectId": project_id, "candidateId": candidate_id},
+    )
+    response.raise_for_status()
+    _print_response(f"PUT personalvoices/{personal_voice_id}", response)
+    return response.json()["speakerProfileId"]
+
+
+# Step 5: synthesize speech using the new personal voice. Identical to any other personal voice.
+def synthesize(speaker_profile_id: str, text: str, output_path: str) -> None:
+    ssml = (
+        "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' "
+        "xmlns:mstts='http://www.w3.org/2001/mstts' xml:lang='en-US'>"
+        "<voice name='DragonLatestNeural'>"
+        f"<mstts:ttsembedding speakerProfileId='{speaker_profile_id}'>"
+        f"<lang xml:lang='{LOCALE}'>{text}</lang>"
+        "</mstts:ttsembedding></voice></speak>"
+    )
+
+    speech_config = speechsdk.SpeechConfig(subscription=SPEECH_KEY, region=SPEECH_REGION)
+    speech_config.set_speech_synthesis_output_format(speechsdk.SpeechSynthesisOutputFormat.Riff24Khz16BitMonoPcm)
+    audio_config = speechsdk.audio.AudioOutputConfig(filename=output_path)
+    synthesizer = speechsdk.SpeechSynthesizer(speech_config=speech_config, audio_config=audio_config)
+
+    result = synthesizer.speak_ssml_async(ssml).get()
+    if result.reason == speechsdk.ResultReason.SynthesizingAudioCompleted:
+        print(f"Synthesized audio -> {output_path}")
+    elif result.reason == speechsdk.ResultReason.Canceled:
+        details = result.cancellation_details
+        raise RuntimeError(f"Synthesis canceled: {details.reason}. {details.error_details}")
+
+
+def main() -> int:
+    if SPEECH_KEY.startswith("<"):
+        print("ERROR: SPEECH_KEY is not set. Edit the constant at the top of this file or set the SPEECH_KEY env var.")
+        return 1
+
+    ensure_project(PROJECT_ID)
+
+    candidates = design_voice_candidates(VOICE_PROMPT, SAMPLE_TEXT, LOCALE, CANDIDATE_COUNT)
+    download_previews(candidates, OUTPUT_DIR)
+
+    if not 0 <= CANDIDATE_INDEX < len(candidates):
+        print(f"ERROR: CANDIDATE_INDEX={CANDIDATE_INDEX} is out of range (got {len(candidates)} candidates).")
+        return 1
+    chosen = candidates[CANDIDATE_INDEX]
+
+    speaker_profile_id = create_personal_voice(PROJECT_ID, PERSONAL_VOICE_ID, chosen["id"])
+
+    output_path = os.path.join(OUTPUT_DIR, "voice_design_output.wav")
+    synthesize(speaker_profile_id, SYNTHESIS_TEXT, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Summary

Add Python and C# samples that demonstrate voice design — creating a personal voice from a text prompt.

# Changes

- New `samples/custom-voice/python/voice_design_sample.py` — minimal end-to-end Python sample (REST for project + design + create personal voice, Speech SDK for synthesis).
- New `samples/custom-voice/csharp/CustomVoiceSample/VoiceDesignSample.cs` — C# counterpart with the same five steps.
- `samples/custom-voice/csharp/CustomVoiceSample/Program.cs` — added a commented-out entry point for the new sample, alongside the existing professional-voice entry.
- `samples/custom-voice/python/README.md` — simplified the run-the-sample section to a plain list of all three samples.

