### PR TITLE
[SECURITY] Upgrade jackson-core and netty in tts-text-stream samples

### DIFF
--- a/samples/java/android/tts-text-stream/app/build.gradle
+++ b/samples/java/android/tts-text-stream/app/build.gradle
@@ -45,6 +45,7 @@ task prepareKotlinBuildScriptModel {}
 dependencies {
     // Speech SDK
     implementation 'com.microsoft.cognitiveservices.speech:client-sdk:1.50.0'
+    implementation platform('io.netty:netty-bom:4.2.13.Final')
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/samples/java/jre/tts-text-stream/pom.xml
+++ b/samples/java/jre/tts-text-stream/pom.xml
@@ -26,6 +26,28 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.21.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.13.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>4.2.13.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <sourceDirectory>src</sourceDirectory>
         <plugins>


### PR DESCRIPTION
## Summary

The two `tts-text-stream` samples (JRE + Android) were the only Java/Android public samples missed by #3034 *Upgrade Netty dependencies in Java/Android public samples*. This PR closes that gap with the same fix pattern used in the other ~12 samples.

## Why

* **JRE sample** `samples/java/jre/tts-text-stream/pom.xml` declares `com.azure:azure-core:1.54.1`, which transitively pulls `jackson-core 2.17.2` and older Netty. Without dependency management overrides, builds resolve vulnerable versions (CVE-2025-58056 Netty, CVE-2026-42583 Lz4FrameDecoder, CVE-2025-52999 jackson-core stack overflow, etc.).
* **Android sample** `samples/java/android/tts-text-stream/app/build.gradle` was the only Android sample without the `io.netty:netty-bom` platform constraint that #3034 added everywhere else.

## Changes

### `samples/java/jre/tts-text-stream/pom.xml` (+22 lines)
Add `<dependencyManagement>` block matching the canonical pattern from `samples/java/jre/console/pom.xml`:

* `com.fasterxml.jackson.core:jackson-core` → **2.21.1**
* `io.netty:netty-bom` → **4.2.13.Final** (imported)
* `io.netty:netty-codec-http2` → **4.2.13.Final**

### `samples/java/android/tts-text-stream/app/build.gradle` (+1 line)
Add one line immediately after the Speech SDK `implementation`:

```gradle
implementation platform('io.netty:netty-bom:4.2.13.Final')
```

This matches all other Android samples (`call-center`, `compressed-input`, `embedded-speech`, `intent-recognition`, `keyword-recognition`, etc.).

## Validation

* `[xml]` cast of the updated pom parses without error.
* Diff is exactly +23 lines, no whitespace-only changes.
* netty-bom line is byte-identical to the line added by #3034 in the other 12 Android samples.
* No version bumps to the Speech SDK or any runtime dependency — only build-time dependency pins to pull patched transitives.

## Related

* #3034 — Upgrade Netty dependencies in Java/Android public samples (this PR fills the gap)
* #3028 — Fix Android TTS text stream sample
* #3035 — Update sample for 1.50.0 (last commit to these files)