### PR TITLE
Fix browser translation sample to use public translations API

### DIFF
--- a/samples/js/browser/index.html
+++ b/samples/js/browser/index.html
@@ -529,10 +529,8 @@
                     }
 
                     if (result.translations) {
-                        var resultJson = JSON.parse(result.json);
-                        resultJson['privTranslationPhrase']['Translation']['Translations'].forEach(
-                            function (translation) {
-                            phraseDiv.innerHTML += ` [${translation.Language}] ${translation.Text}\r\n`;
+                        result.translations.languages.forEach(function (language) {
+                            phraseDiv.innerHTML += ` [${language}] ${result.translations.get(language)}\r\n`;
                         });
                     }
 

--- a/samples/js/browser/public/index.html
+++ b/samples/js/browser/public/index.html
@@ -524,10 +524,8 @@
                     }
 
                     if (result.translations) {
-                        var resultJson = JSON.parse(result.json);
-                        resultJson['privTranslationPhrase']['Translation']['Translations'].forEach(
-                            function (translation) {
-                            phraseDiv.innerHTML += ` [${translation.Language}] ${translation.Text}\r\n`;
+                        result.translations.languages.forEach(function (language) {
+                            phraseDiv.innerHTML += ` [${language}] ${result.translations.get(language)}\r\n`;
                         });
                     }
                     break;


### PR DESCRIPTION
Summary

Fixes: https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/2786 . Recognized speech was shown but translated text never appeared (synthesized translation audio still played).

Root cause

onRecognizedResult parsed the raw result.json and read resultJson['privTranslationPhrase']['Translation']['Translations']. privTranslationPhrase is a private internal field of the SDK result object, not a JSON key — so it was undefined and .forEach threw a TypeError, aborting translation rendering.

Fix

Use the SDK's public Translations API

AI description (iteration 1)
PR Classification
Bug fix to resolve translation results not displaying in the JavaScript browser sample.

PR Summary
Fixes the translation results display issue by replacing direct JSON parsing with the proper SDK API for accessing translation results. This change ensures translation outputs are correctly shown in the browser sample.

index.html and public/index.html: Replaced JSON parsing of result.json with iterating through result.translations.languages and using result.translations.get(language) to retrieve and display translation text for each target language.